### PR TITLE
chore: add WanCli repo mapping and fix wan lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Monorepo for all AceDataCloud command-line interface tools.
 | `seedream/` | [SeedreamCli](https://github.com/AceDataCloud/SeedreamCli) | Seedream image generation CLI |
 | `flux/` | [FluxCli](https://github.com/AceDataCloud/FluxCli) | Flux image generation & editing CLI |
 | `serp/` | [SerpCli](https://github.com/AceDataCloud/SerpCli) | Google SERP (Search) CLI |
+| `wan/` | [WanCli](https://github.com/AceDataCloud/WanCli) | Tongyi Wansiang video generation CLI |
 | `adc/` | [AdcCli](https://github.com/AceDataCloud/AdcCli) | Unified AceDataCloud CLI (all services) |
 
 ## How It Works

--- a/sync.yaml
+++ b/sync.yaml
@@ -49,6 +49,11 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  wan:
+    repo: AceDataCloud/WanCli
+    exclude:
+      - .github
+      - .gitbooks
   adc:
     repo: AceDataCloud/AdcCli
     exclude:

--- a/wan/tests/test_integration.py
+++ b/wan/tests/test_integration.py
@@ -1,5 +1,7 @@
 """Integration tests (require real API token)."""
 
+import contextlib
+
 import pytest
 
 from wan_cli.core.client import WanClient
@@ -22,7 +24,5 @@ def test_query_task_integration(api_token):
     """Test querying a task via real API."""
     client = WanClient(api_token=api_token)
     # Use a dummy task ID - it will return an error but we verify auth works
-    try:
+    with contextlib.suppress(Exception):
         client.query_task(id="test-task-id", action="retrieve")
-    except Exception:
-        pass  # Expected for non-existent task

--- a/wan/tests/test_output.py
+++ b/wan/tests/test_output.py
@@ -1,7 +1,5 @@
 """Tests for output formatting."""
 
-import json
-
 from wan_cli.core.output import (
     DEFAULT_MODEL,
     DURATIONS,
@@ -45,7 +43,7 @@ def test_durations():
     assert 15 in DURATIONS
 
 
-def test_print_json(capsys):
+def test_print_json():
     data = {"key": "value", "number": 42}
     print_json(data)
     # Output goes to console, not capsys - just verify no exception

--- a/wan/wan_cli/core/client.py
+++ b/wan/wan_cli/core/client.py
@@ -86,7 +86,7 @@ class WanClient:
                 ) from e
 
             except Exception as e:
-                if isinstance(e, (WanAPIError, WanTimeoutError)):
+                if isinstance(e, WanAPIError | WanTimeoutError):
                     raise
                 raise WanAPIError(message=str(e)) from e
 


### PR DESCRIPTION
## Summary
- Add `wan -> AceDataCloud/WanCli` mapping to sync.yaml
- Add wan CLI row to README.md table
- Fix ruff lint issues in wan CLI: UP038, SIM105, F401, ARG001

## Test plan
- [x] All ruff lint/format checks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)