### PR TITLE
fix: standardize veo model name to veo31-fast-ingredients

### DIFF
--- a/veo/README.md
+++ b/veo/README.md
@@ -14,7 +14,7 @@ Generate AI videos directly from your terminal — no MCP client required.
 
 - **Video Generation** — Generate videos from text prompts with multiple models
 - **Image-to-Video** — Create videos from reference images- **Video Upscale** — Get 1080p versions of generated videos
-- **Multiple Models** — veo3, veo3-fast, veo31, veo31-fast, veo31-fast-ingredient, veo2, veo2-fast
+- **Multiple Models** — veo3, veo3-fast, veo31, veo31-fast, veo31-fast-ingredients, veo2, veo2-fast
 - **Task Management** — Query tasks, batch query, wait with polling
 - **Rich Output** — Beautiful terminal tables and panels via Rich
 - **JSON Mode** — Machine-readable output with `--json` for piping
@@ -117,7 +117,7 @@ Most commands support:
 | `veo3-fast` | V3 Fast | Fast generation |
 | `veo31` | V3.1 | Next generation model |
 | `veo31-fast` | V3.1 Fast | Fast next-gen model |
-| `veo31-fast-ingredient` | V3.1 Fast Ingredient | Ingredient-based fast next-gen model |
+| `veo31-fast-ingredients` | V3.1 Fast Ingredient | Ingredient-based fast next-gen model |
 | `veo2` | V2 | Previous generation, stable |
 | `veo2-fast` | V2 Fast | Fast previous-gen model |
 

--- a/veo/tests/test_commands.py
+++ b/veo/tests/test_commands.py
@@ -86,7 +86,7 @@ class TestGenerateCommands:
         )
         result = runner.invoke(
             cli,
-            ["--token", "test-token", "generate", "test", "-m", "veo31-fast-ingredient", "--json"],
+            ["--token", "test-token", "generate", "test", "-m", "veo31-fast-ingredients", "--json"],
         )
         assert result.exit_code == 0
 
@@ -243,7 +243,7 @@ class TestInfoCommands:
         result = runner.invoke(cli, ["models"])
         assert result.exit_code == 0
         assert "veo3" in result.output
-        assert "veo31-fast-ingredient" in result.output
+        assert "veo31-fast-ingredients" in result.output
 
     def test_aspect_ratios(self, runner):
         result = runner.invoke(cli, ["aspect-ratios"])

--- a/veo/tests/test_output.py
+++ b/veo/tests/test_output.py
@@ -29,7 +29,7 @@ class TestConstants:
             "veo3-fast",
             "veo31",
             "veo31-fast",
-            "veo31-fast-ingredient",
+            "veo31-fast-ingredients",
             "veo2",
             "veo2-fast",
         ]:

--- a/veo/veo_cli/core/output.py
+++ b/veo/veo_cli/core/output.py
@@ -15,7 +15,7 @@ VEO_MODELS = [
     "veo3-fast",
     "veo31",
     "veo31-fast",
-    "veo31-fast-ingredient",
+    "veo31-fast-ingredients",
     "veo2",
     "veo2-fast",
 ]
@@ -148,7 +148,7 @@ def print_models() -> None:
         "Fast next-gen model",
     )
     table.add_row(
-        "veo31-fast-ingredient",
+        "veo31-fast-ingredients",
         "V3.1 Fast Ingredient",
         "Ingredient-based fast next-gen model",
     )


### PR DESCRIPTION
## Summary
- Fix Veo CLI output, tests, and README to use `veo31-fast-ingredients`

🤖 Generated with [Claude Code](https://claude.com/claude-code)