### PR TITLE
feat(midjourney): add V8.1 to MIDJOURNEY_VERSIONS and refresh help text

### DIFF
--- a/midjourney/midjourney_cli/commands/imagine.py
+++ b/midjourney/midjourney_cli/commands/imagine.py
@@ -29,13 +29,13 @@ from midjourney_cli.core.output import (
     "mj_version",
     type=click.Choice(MIDJOURNEY_VERSIONS),
     default=None,
-    help="Midjourney model version (5.2, 6, 6.1, 7, 8).",
+    help="Midjourney model version (5.2, 6, 6.1, 7, 8, 8.1). '8.1' is the latest and is recommended.",
 )
 @click.option("--translation/--no-translation", default=False, help="Auto-translate to English.")
 @click.option(
     "--split/--no-split", "split_images", default=False, help="Split 2x2 grid into 4 images."
 )
-@click.option("--hd", is_flag=True, default=False, help="Enable HD mode (V8 only, 4x cost).")
+@click.option("--hd", is_flag=True, default=False, help="Enable HD mode (V8/V8.1 only; default on V8.1).")
 @click.option(
     "--quality",
     default=None,

--- a/midjourney/midjourney_cli/commands/imagine.py
+++ b/midjourney/midjourney_cli/commands/imagine.py
@@ -35,7 +35,9 @@ from midjourney_cli.core.output import (
 @click.option(
     "--split/--no-split", "split_images", default=False, help="Split 2x2 grid into 4 images."
 )
-@click.option("--hd", is_flag=True, default=False, help="Enable HD mode (V8/V8.1 only; default on V8.1).")
+@click.option(
+    "--hd", is_flag=True, default=False, help="Enable HD mode (V8/V8.1 only; default on V8.1)."
+)
 @click.option(
     "--quality",
     default=None,

--- a/midjourney/midjourney_cli/core/output.py
+++ b/midjourney/midjourney_cli/core/output.py
@@ -14,7 +14,7 @@ MIDJOURNEY_MODES = ["fast", "relax", "turbo"]
 DEFAULT_MODE = "fast"
 
 # Available versions
-MIDJOURNEY_VERSIONS = ["5.2", "6", "6.1", "7", "8"]
+MIDJOURNEY_VERSIONS = ["5.2", "6", "6.1", "7", "8", "8.1"]
 
 # Available imagine actions
 IMAGINE_ACTIONS = [

--- a/midjourney/tests/test_output.py
+++ b/midjourney/tests/test_output.py
@@ -27,6 +27,7 @@ class TestConstants:
 
     def test_versions(self):
         assert "8" in MIDJOURNEY_VERSIONS
+        assert "8.1" in MIDJOURNEY_VERSIONS
 
     def test_actions(self):
         assert "generate" in IMAGINE_ACTIONS


### PR DESCRIPTION
## Why

[Midjourney V8.1](https://updates.midjourney.com/v8-1-alpha/) is now GA. The Midjourney CLI needs to accept `--version 8.1` (currently rejected by `click.Choice`).

## What

- `midjourney/midjourney_cli/core/output.py`: add `"8.1"` to `MIDJOURNEY_VERSIONS` so `click.Choice` accepts `--version 8.1`.
- `midjourney/midjourney_cli/commands/imagine.py`: refresh `--version` help text to include 8.1 (recommended); tweak `--hd` help text since HD is default on V8.1.
- `midjourney/tests/test_output.py`: add an assertion that `"8.1"` is in `MIDJOURNEY_VERSIONS`.

## Tests

```
pytest tests/test_output.py -v
======================== 18 passed, 1 warning in 0.17s =========================
```

## Related

- AceDataCloud/PlatformBackend#472 — V8.1 cost rules + OpenAPI + tests
- AceDataCloud/PlatformService#885 — ttapi worker V8.1 detection fix
- AceDataCloud/Nexior#733 — Nexior V8.1 selectors + isV8 checks
- AceDataCloud/MCPs (companion PR)