### PR TITLE
sync: add deepseek-v4-flash to aichat models [auto-sync]

### DIFF
--- a/aichat/aichat_cli/core/output.py
+++ b/aichat/aichat_cli/core/output.py
@@ -83,6 +83,7 @@ MODELS = [
     "deepseek-r1-0528",
     "deepseek-v3",
     "deepseek-v3-250324",
+    "deepseek-v4-flash",
     "grok-3",
     "glm-5.1",
     "glm-4.7",

--- a/aichat/tests/test_client.py
+++ b/aichat/tests/test_client.py
@@ -45,9 +45,7 @@ class TestAichatClient:
             )
         )
         client = AichatClient(api_token="test-token")
-        result = client.request(
-            "/aichat/conversations", {"question": "Hi", "model": "gpt-4o"}
-        )
+        result = client.request("/aichat/conversations", {"question": "Hi", "model": "gpt-4o"})
         assert result["id"] == "abc123"
         assert result["answer"] == "Hello!"
 

--- a/aichat/tests/test_config.py
+++ b/aichat/tests/test_config.py
@@ -1,7 +1,5 @@
 """Tests for configuration."""
 
-import os
-
 import pytest
 
 from aichat_cli.core.config import Settings


### PR DESCRIPTION
## Why
Downstream auto-sync (Docs → Clis) has been failing since 2026-06-06 — the Copilot cloud agent dies on `402 quota_exceeded`. Manual reconciliation of the genuine drift.

## What drifted
Full scan of every Clis model list vs `Docs/openapi/*.json` found **only `aichat` out of sync** (flux, glm, openai, and all media CLIs already current).

- **aichat**: add `deepseek-v4-flash` to `MODELS` (present in the Docs aichat enum, missing here)
- drive-by lint fixes so aichat CI is green again: remove unused `os` import, `ruff format` `test_client.py` (both pre-existing drift on main)

## Verification
- `pytest` — 30 passed
- `ruff check .` / `ruff format --check .` — clean

> Root cause (org Copilot premium-request quota exhausted) is unaddressed; this only clears the current Clis backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)