### PR TITLE
refactor(cli): use async:true instead of dummy health callback

### DIFF
--- a/adc/adc_cli/core/client.py
+++ b/adc/adc_cli/core/client.py
@@ -11,9 +11,6 @@ from adc_cli.core.exceptions import (
     AdcTimeoutError,
 )
 
-# Dummy callback URL to force async mode for long-running operations.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 
 class AdcClient:
     """HTTP client for AceDataCloud API."""
@@ -39,7 +36,7 @@ class AdcClient:
         """Ensure long-running operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def request(

--- a/adc/tests/test_client.py
+++ b/adc/tests/test_client.py
@@ -42,7 +42,7 @@ class TestAdcClient:
         client = AdcClient(api_token="test-token")
         payload = {"prompt": "test"}
         result = client._with_async_callback(payload)
-        assert result["callback_url"] == "https://api.acedata.cloud/health"
+        assert result["async"] is True
         assert result["prompt"] == "test"
         # Original should not be modified
         assert "callback_url" not in payload
@@ -126,7 +126,7 @@ class TestConvenienceMethods:
         result = client.flux_image(prompt="sunset", model="flux-dev")
         assert result["task_id"] == "flux-1"
         body = json.loads(route.calls.last.request.content)
-        assert body["callback_url"] == "https://api.acedata.cloud/health"
+        assert body["async"] is True
 
     @respx.mock
     def test_midjourney_imagine(self):
@@ -137,7 +137,7 @@ class TestConvenienceMethods:
         result = client.midjourney_imagine(prompt="city")
         assert result["task_id"] == "mj-1"
         body = json.loads(route.calls.last.request.content)
-        assert "callback_url" in body
+        assert body["async"] is True
 
     @respx.mock
     def test_suno_music(self):
@@ -148,7 +148,7 @@ class TestConvenienceMethods:
         result = client.suno_music(action="generate", prompt="jazz")
         assert result["task_id"] == "suno-1"
         body = json.loads(route.calls.last.request.content)
-        assert "callback_url" in body
+        assert body["async"] is True
 
     @respx.mock
     def test_luma_video(self):

--- a/flux/flux_cli/core/client.py
+++ b/flux/flux_cli/core/client.py
@@ -11,9 +11,6 @@ from flux_cli.core.exceptions import (
     FluxTimeoutError,
 )
 
-# Dummy callback URL to force async mode.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 
 class FluxClient:
     """HTTP client for AceDataCloud Flux API."""
@@ -37,7 +34,7 @@ class FluxClient:
         """Ensure long-running operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def request(

--- a/flux/tests/test_client.py
+++ b/flux/tests/test_client.py
@@ -137,7 +137,7 @@ class TestFluxClient:
         import json
 
         body = json.loads(route.calls.last.request.content)
-        assert "callback_url" in body
+        assert body["async"] is True
 
     @respx.mock
     def test_with_async_callback_preserves_custom(self):

--- a/midjourney/midjourney_cli/core/client.py
+++ b/midjourney/midjourney_cli/core/client.py
@@ -11,9 +11,6 @@ from midjourney_cli.core.exceptions import (
     MidjourneyTimeoutError,
 )
 
-# Dummy callback URL to force async mode — returns 200 OK immediately.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 
 class MidjourneyClient:
     """HTTP client for AceDataCloud Midjourney API."""
@@ -37,7 +34,7 @@ class MidjourneyClient:
         """Ensure long-running operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def request(

--- a/midjourney/tests/test_client.py
+++ b/midjourney/tests/test_client.py
@@ -40,7 +40,7 @@ class TestMidjourneyClient:
         client = MidjourneyClient(api_token="test-token")
         payload = {"prompt": "test"}
         result = client._with_async_callback(payload)
-        assert "callback_url" in result
+        assert result["async"] is True
         assert result["prompt"] == "test"
 
     def test_async_callback_preserves_existing(self):


### PR DESCRIPTION
## What

The `adc`, `flux`, and `midjourney` CLIs forced async submission by injecting a dummy `callback_url = https://api.acedata.cloud/health` (same hack the MCP servers used). The API now supports an explicit `async: true` flag, so submit with that instead — no more useless POST to the health endpoint per task.

- `_with_async_callback`: inject `{"async": true}` when no `callback_url` provided
- drop the unused `_ASYNC_CALLBACK_URL` constant
- update `adc/tests/test_client.py` assertions (21 pass)

Mirrors the MCP change (AceDataCloud/MCPs#395). Relies on worker async:true (PS#1019).

## Note

CLIs that expose `--callback-url` directly (suno, veo, sora, etc.) still let users pass a real webhook; adding a user-facing `--async` flag to those per-command is a separate follow-up (lower value — those already run sync-by-default and users can poll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)