### PR TITLE
fix(ci): repair both CLI sync pipelines (Docs→Clis and Clis→mirrors)

### DIFF
--- a/.github/workflows/sync-from-docs.yml
+++ b/.github/workflows/sync-from-docs.yml
@@ -182,8 +182,21 @@ jobs:
                 echo "Tracking PR #$PR_NUMBER (draft=$IS_DRAFT, +$ADDITIONS/-$DELETIONS)"
               fi
 
-              # Reliable completion signal: Copilot marks the PR ready-for-review
-              # itself when its agent finishes successfully.
+              # Primary completion signal: Copilot emits a `copilot_work_finished`
+              # timeline event when its agent finishes. It now leaves the PR as a DRAFT
+              # (only fires copilot_work_finished + review_requested, never ready_for_review),
+              # so the old `isDraft == false` check below never fired and good PRs were
+              # discarded. The Merge step force-readies the draft before merging.
+              WORK_DONE=$(gh api "repos/$REPO/issues/$PR_NUMBER/timeline" --paginate \
+                --jq '[.[] | select(.event == "copilot_work_finished")] | length' 2>/dev/null || echo 0)
+              if [ "${WORK_DONE:-0}" -gt 0 ]; then
+                echo "PR #$PR_NUMBER: Copilot emitted copilot_work_finished — agent done (draft=$IS_DRAFT)."
+                echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+                echo "result=ready" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+
+              # Secondary signal: Copilot marked the PR ready-for-review itself.
               if [ "$IS_DRAFT" = "false" ]; then
                 echo "PR #$PR_NUMBER is ready for review — Copilot finished."
                 echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
@@ -191,16 +204,19 @@ jobs:
                 exit 0
               fi
 
-              # Zombie guard: if PR has been open >30 min with 0 commits, give up.
+              # Zombie guard: PR open >30 min with 0 commits and no finish signal means
+              # Copilot produced nothing (nothing to sync, or it stalled). Close it and
+              # treat as a no-op success — a missed sync is recovered by the next dispatch,
+              # so don't fail the build and create false-alarm red CI.
               if [ "$ADDITIONS" = "0" ] && [ "$DELETIONS" = "0" ]; then
                 created_epoch=$(date -d "$CREATED_AT" +%s 2>/dev/null || python3 -c "import datetime,sys; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$CREATED_AT")
                 age=$((now - created_epoch))
                 if [ "$age" -gt "$ZOMBIE_GRACE_SECONDS" ]; then
-                  echo "::warning::PR #$PR_NUMBER has 0 commits after ${age}s — closing as zombie."
+                  echo "::warning::PR #$PR_NUMBER has 0 commits after ${age}s — closing as no-op."
                   gh pr close "$PR_NUMBER" --repo "$REPO" --delete-branch \
-                    --comment "Auto-closed: Copilot opened this PR but produced no commits within ${ZOMBIE_GRACE_SECONDS}s. Triggering workflow can be re-dispatched if a sync is still needed." 2>/dev/null || true
+                    --comment "Auto-closed: Copilot opened this PR but produced no commits within ${ZOMBIE_GRACE_SECONDS}s. Re-dispatch the workflow if a sync is still needed." 2>/dev/null || true
                   echo "result=zombie-closed" >> "$GITHUB_OUTPUT"
-                  exit 1
+                  exit 0
                 fi
               fi
             fi

--- a/.github/workflows/sync-to-repos.yml
+++ b/.github/workflows/sync-to-repos.yml
@@ -3,6 +3,12 @@ name: Sync to Sub-Repos
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      sync_all:
+        description: "Force-sync every mapped dir (full catch-up, ignores git diff)"
+        type: boolean
+        default: true
 
 jobs:
   detect-changes:
@@ -18,6 +24,13 @@ jobs:
       - name: Detect changed subdirectories
         id: changes
         run: |
+          # Full catch-up when manually dispatched with sync_all: mirror every mapped dir
+          # regardless of git diff. Used to recover after the sync was stalled (e.g. expired token).
+          FULL_SYNC="false"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.sync_all }}" = "true" ]; then
+            FULL_SYNC="true"
+          fi
+
           # Get list of changed files
           CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD)
 
@@ -28,7 +41,7 @@ jobs:
           HAS_CHANGES="false"
 
           for dir in $DIRS; do
-            if echo "$CHANGED" | grep -q "^${dir}/"; then
+            if [ "$FULL_SYNC" = "true" ] || echo "$CHANGED" | grep -q "^${dir}/"; then
               # Extract repo from sync.yaml
               REPO=$(awk "/^  ${dir}:/{found=1} found && /repo:/{print \$2; exit}" sync.yaml)
               if [ -n "$REPO" ]; then
@@ -54,7 +67,10 @@ jobs:
 
       - name: Sync ${{ matrix.dir }} to ${{ matrix.repo }}
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+          # Prefer the org-maintained admin/bot tokens (rotated centrally) and fall back to
+          # the repo SYNC_TOKEN. SYNC_TOKEN silently expired once (Apr 2026) and froze every
+          # mirror for months — don't depend on a single manually-maintained secret alone.
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN || secrets.BOT_GITHUB_TOKEN || secrets.SYNC_TOKEN }}
         run: |
           set -e
 


### PR DESCRIPTION
## Why

The CLI sync was broken in **two** independent places, which is why every standalone \`*Cli\` repo looked frozen since ~April and no new models reached the CLIs since mid-June:

### 1. \`sync-from-docs.yml\` — Copilot's real work was being discarded
\`wait-and-merge\` used \`isDraft == false\` as the *only* completion signal. But the Copilot coding agent now finishes by firing \`copilot_work_finished\` + \`review_requested\` and **leaves the PR as a draft** — it never emits \`ready_for_review\`. So the signal never fired, the job timed out after 55 min (\`exit 1\`), and the *next* dispatch closed the finished PR unmerged.

Evidence (PR #368, a real Suno sync):
\`\`\`
13:22:07  Tracking PR #368 (draft=true, +0/-0)
13:29:50  copilot_work_finished      ← agent done
13:29:51  review_requested            ← (no ready_for_review event)
14:19:49  Timed out waiting for Copilot to mark PR ready for review.  exit 1
16:49:29  closed by next dispatch
\`\`\`
Real work lost this way over the past week: kling lip-sync (#370), suno voices (#366), suno sync (#368).

**Fix:** detect completion via the \`copilot_work_finished\` timeline event (the Merge step already force-readies the draft before \`--admin\` merge). Also treat a genuine 0-commit zombie as a **no-op success** instead of failing the build — a missed sync is recovered by the next dispatch, so it shouldn't paint CI red.

### 2. \`sync-to-repos.yml\` — expired token froze every mirror
The mirror push used \`secrets.SYNC_TOKEN\`, a standalone PAT last set **2026-04-04** that has since expired:
\`\`\`
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/AceDataCloud/SoraCli.git/'
\`\`\`
That's why every \`*Cli\` mirror has been frozen at ~2026-04-05.

**Fix:** prefer the org-maintained \`ADMIN_GITHUB_TOKEN || BOT_GITHUB_TOKEN\` (rotated centrally, also used by \`sync-from-docs\`) and keep \`SYNC_TOKEN\` only as a last fallback — so a single manually-maintained secret can't silently freeze the mirrors again. Also added a \`workflow_dispatch\` \`sync_all\` input to force a **full catch-up mirror** of every mapped dir (to clear the April–June backlog in one run).

## Follow-up after merge
- Run \`Sync to Sub-Repos\` via \`workflow_dispatch\` (sync_all=true) to push the accumulated monorepo state to all 12 \`*Cli\` repos.
- Re-dispatch \`Sync from Docs\` to regenerate the lost kling/suno work, which should now actually merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)