### PR TITLE
fix(ci): serialize Sync from Docs to stop PR cannibalization

### DIFF
--- a/.github/workflows/sync-from-docs.yml
+++ b/.github/workflows/sync-from-docs.yml
@@ -10,6 +10,14 @@ permissions:
   issues: write
   pull-requests: write
 
+# Serialize runs. create-task closes ALL open copilot/* PRs + auto-sync issues, so an
+# overlapping run cannibalizes the in-flight run's still-working PR — that is exactly what
+# happened to PR #377 (closed by the next dispatch 22s before Copilot finished). With
+# cancel-in-progress:false a new Docs dispatch queues behind the current run instead.
+concurrency:
+  group: sync-from-docs
+  cancel-in-progress: false
+
 jobs:
   create-task:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Follow-up to #375. After that fix, the re-dispatched \`Sync from Docs\` run still failed to land its work — but for a **different** reason: concurrent runs cannibalize each other.

\`create-task\` closes **every** open \`copilot/*\` PR and **every** open \`auto-sync\` issue at the start of each run (intended to clear stale drafts). But Docs dispatches arrive ~8–10 min apart, so a newer run's cleanup kills the previous run's *still-in-progress* PR.

Observed on PR #377:
\`\`\`
05:57:52  Initial plan
06:03:55  feat: sync CLI tools with Docs OpenAPI updates   ← real work committed
06:05:10  next Docs dispatch starts a new run
06:05:19  #377 closed + branch deleted by the new run's create-task
06:05:41  copilot_work_finished                            ← 22s too late
\`\`\`
The orphaned run then reported a **false "no-op success"** because its issue (#376) had been closed out from under it by the competing run.

## Fix

Add a workflow-level concurrency group with \`cancel-in-progress: false\`, so a new dispatch **queues behind** the in-flight run instead of starting concurrently and running its destructive cleanup mid-flight. Each run now gets to finish (and merge its PR) before the next one starts — at which point there are genuinely no leftovers to clean up.

\`cancel-in-progress: false\` (queue) not \`true\` (cancel) on purpose: cancelling the in-flight run would discard Copilot's work, which is the very thing we're protecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)