### PR TITLE
feat: map hailuo/kling/webextrator/openai/aichat/glm CLIs to standalone repos

### DIFF
--- a/sync.yaml
+++ b/sync.yaml
@@ -54,3 +54,33 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  hailuo:
+    repo: AceDataCloud/HailuoCli
+    exclude:
+      - .github
+      - .gitbooks
+  kling:
+    repo: AceDataCloud/KlingCli
+    exclude:
+      - .github
+      - .gitbooks
+  webextrator:
+    repo: AceDataCloud/WebExtratorCli
+    exclude:
+      - .github
+      - .gitbooks
+  openai:
+    repo: AceDataCloud/OpenAICli
+    exclude:
+      - .github
+      - .gitbooks
+  aichat:
+    repo: AceDataCloud/AiChatCli
+    exclude:
+      - .github
+      - .gitbooks
+  glm:
+    repo: AceDataCloud/GlmCli
+    exclude:
+      - .github
+      - .gitbooks


### PR DESCRIPTION
## What

The organization homepage auto-generator only lists CLI tools whose **standalone repo + PyPI package both exist**. Six CLI tools existed as monorepo subdirs but had **no `sync.yaml` mapping**, so they were never split into standalone repos and never published — invisible on the homepage.

This PR adds the missing mappings so the CLIs sync to standalone repos:

| dir | repo | PyPI package |
|---|---|---|
| `hailuo` | `AceDataCloud/HailuoCli` | `hailuo-cli` |
| `kling` | `AceDataCloud/KlingCli` | `kling-pro-cli` |
| `webextrator` | `AceDataCloud/WebExtratorCli` | `webextrator-cli` |
| `openai` | `AceDataCloud/OpenAICli` | `openai-cli` |
| `aichat` | `AceDataCloud/AiChatCli` | `aichat-cli` |
| `glm` | `AceDataCloud/GlmCli` | `glm-cli` |

The standalone repos were created and bootstrapped with source + a `publish.yml` (CLI convention keeps `publish.yml` in the standalone repo, since `.github` is excluded from CLI sync), and their first PyPI publish was triggered.

## 🤖 对抗评审

- **`.github` excluded for CLIs:** confirmed — each new entry carries `exclude: [.github, .gitbooks]`, so the standalone repo's own `publish.yml` survives future `rsync --delete` syncs. OK.
- **CalVer vs existing SemVer (`openai-cli` 1.0.1, `aichat-cli` 0.5.1, `glm-cli` 0.1.0):** CalVer `2026.6.x` > those under PEP 440 — no downgrade. OK.
- **YAML validity:** `yaml.safe_load` parses to 17 mappings. OK.
- **Secrets:** org-level `PYPI_TOKEN`, none hardcoded. OK.

VERDICT: CLEAN
