### PR TITLE
fix(seedance): default CLI to live doubao-seedance-2-0-260128

### DIFF
--- a/seedance/README.md
+++ b/seedance/README.md
@@ -14,7 +14,7 @@ Generate AI videos directly from your terminal — no MCP client required.
 
 - **Video Generation** — Generate videos from text prompts with multiple models
 - **Image-to-Video** — Create videos from reference images
-- **Multiple Models** — doubao-seedance-1-5-pro-251215, doubao-seedance-1-0-pro-250528, doubao-seedance-1-0-pro-fast-251015, doubao-seedance-1-0-lite-t2v-250428, doubao-seedance-1-0-lite-i2v-250428
+- **Multiple Models** — Seedance 2.0 series (doubao-seedance-2-0-260128, doubao-seedance-2-0-fast-260128, doubao-seedance-2-0-mini-260615) plus doubao-seedance-1-5-pro-251215, doubao-seedance-1-0-pro-250528, doubao-seedance-1-0-pro-fast-251015, doubao-seedance-1-0-lite-t2v-250428, doubao-seedance-1-0-lite-i2v-250428
 - **Task Management** — Query tasks, batch query, wait with polling
 - **Rich Output** — Beautiful terminal tables and panels via Rich
 - **JSON Mode** — Machine-readable output with `--json` for piping
@@ -101,7 +101,7 @@ Most commands support:
 
 ```
 --json                       Output raw JSON (for piping/scripting)
---model TEXT                 Seedance model version (default: doubao-seedance-1-0-pro-250528)
+--model TEXT                 Seedance model version (default: doubao-seedance-2-0-260128)
 --aspect-ratio TEXT          Aspect ratio (16:9, 9:16, 1:1, 4:3, 3:4, 21:9, adaptive)
 --resolution TEXT            Output resolution (480p, 720p, 1080p, 4k)
 --duration FLOAT             Duration in seconds (2–15). Mutually exclusive with --frames.
@@ -109,7 +109,7 @@ Most commands support:
 --seed INT                   Random seed for reproducible generation (-1 for random).
 --camerafixed BOOL           Fix the camera position (true/false).
 --watermark BOOL             Add a watermark to the output (true/false).
---generate-audio BOOL        Generate audio (true/false). Only doubao-seedance-1-5-pro-251215.
+--generate-audio BOOL        Generate audio (true/false). Supported by doubao-seedance-1-5-pro-251215 and the doubao-seedance-2-0 series.
 --return-last-frame BOOL     Return the last frame of the video (true/false).
 --service-tier TEXT          Service level (default/flex).
 --execution-expires-after INT  Task timeout in seconds (3600–259200).
@@ -125,12 +125,12 @@ Most commands support:
 
 | Model | Version | Notes |
 |-------|---------|-------|
-| `doubao-seedance-1-5-pro-251215` | V1.5 Pro | Newest, supports audio generation |
-| `doubao-seedance-1-0-pro-250528` | V1.0 Pro | Standard quality (default) |
+| `doubao-seedance-1-5-pro-251215` | V1.5 Pro | Newest 1.x, supports audio generation |
+| `doubao-seedance-1-0-pro-250528` | V1.0 Pro | Standard quality |
 | `doubao-seedance-1-0-pro-fast-251015` | V1.0 Fast | Faster generation |
 | `doubao-seedance-1-0-lite-t2v-250428` | V1.0 Lite T2V | Lightweight text-to-video |
 | `doubao-seedance-1-0-lite-i2v-250428` | V1.0 Lite I2V | Lightweight image-to-video |
-| `doubao-seedance-2-0-260128` | V2.0 | Next-generation general model |
+| `doubao-seedance-2-0-260128` | V2.0 | Next-generation general model (default) |
 | `doubao-seedance-2-0-fast-260128` | V2.0 Fast | Faster next-generation generation |
 | `doubao-seedance-2-0-mini-260615` | V2.0 Mini | Compact next-generation model |
 
@@ -143,7 +143,7 @@ Most commands support:
 |----------|-------------|---------|
 | `ACEDATACLOUD_API_TOKEN` | API token from AceDataCloud | *Required* |
 | `ACEDATACLOUD_API_BASE_URL` | API base URL | `https://api.acedata.cloud` |
-| `SEEDANCE_DEFAULT_MODEL` | Default model | `doubao-seedance-1-0-pro-250528` |
+| `SEEDANCE_DEFAULT_MODEL` | Default model | `doubao-seedance-2-0-260128` |
 | `SEEDANCE_REQUEST_TIMEOUT` | Timeout in seconds | `1800` |
 
 ## Development

--- a/seedance/seedance_cli/commands/video.py
+++ b/seedance/seedance_cli/commands/video.py
@@ -16,6 +16,8 @@ from seedance_cli.core.output import (
 )
 
 _SERVICE_TIERS = ["default", "flex"]
+
+
 def _shared_video_options(f):  # type: ignore[no-untyped-def]
     """Decorator that attaches options shared by generate and image-to-video."""
     decorators = [
@@ -74,7 +76,7 @@ def _shared_video_options(f):  # type: ignore[no-untyped-def]
             "--generate-audio",
             type=click.BOOL,
             default=None,
-            help="Generate audio for the video (true/false). Only doubao-seedance-1-5-pro-251215 supports this.",
+            help="Generate audio for the video (true/false). Supported by doubao-seedance-1-5-pro-251215 and the doubao-seedance-2-0 series.",
         ),
         click.option(
             "--return-last-frame",

--- a/seedance/seedance_cli/core/config.py
+++ b/seedance/seedance_cli/core/config.py
@@ -23,7 +23,7 @@ class Settings:
     )
     default_model: str = field(
         default_factory=lambda: os.environ.get(
-            "SEEDANCE_DEFAULT_MODEL", "doubao-seedance-1-0-pro-250528"
+            "SEEDANCE_DEFAULT_MODEL", "doubao-seedance-2-0-260128"
         )
     )
 

--- a/seedance/seedance_cli/core/output.py
+++ b/seedance/seedance_cli/core/output.py
@@ -21,7 +21,7 @@ SEEDANCE_MODELS = [
     "doubao-seedance-2-0-mini-260615",
 ]
 
-DEFAULT_MODEL = "doubao-seedance-1-0-pro-250528"
+DEFAULT_MODEL = "doubao-seedance-2-0-260128"
 
 # Available aspect ratios
 ASPECT_RATIOS = [
@@ -136,12 +136,12 @@ def print_models() -> None:
     table.add_row(
         "doubao-seedance-1-5-pro-251215",
         "V1.5 Pro",
-        "Newest, supports audio generation",
+        "Newest 1.x, supports audio generation",
     )
     table.add_row(
         "doubao-seedance-1-0-pro-250528",
         "V1.0 Pro",
-        "Standard quality (default)",
+        "Standard quality",
     )
     table.add_row(
         "doubao-seedance-1-0-pro-fast-251015",
@@ -161,7 +161,7 @@ def print_models() -> None:
     table.add_row(
         "doubao-seedance-2-0-260128",
         "V2.0",
-        "Next-generation general model",
+        "Next-generation general model (default)",
     )
     table.add_row(
         "doubao-seedance-2-0-fast-260128",

--- a/seedance/tests/test_config.py
+++ b/seedance/tests/test_config.py
@@ -9,7 +9,7 @@ def test_settings_default_values():
     settings = Settings()
     assert settings.api_base_url == "https://api.acedata.cloud"
     assert settings.request_timeout == 1800
-    assert settings.default_model == "doubao-seedance-1-0-pro-250528"
+    assert settings.default_model == "doubao-seedance-2-0-260128"
 
 
 def test_settings_from_environment():


### PR DESCRIPTION
The `seedance` CLI defaulted to `doubao-seedance-1-0-pro-250528`, but the live worker now only accepts the Seedance 2.0 models (`doubao-seedance-2-0-260128` / `-fast-260128` / `-mini-260615`) — so `seedance generate "..."` with default options was rejected with a 400. The CLI's model choices, `4k`, reference audio/video flags and `2–15s` duration were already current; only the **default** and some doc/help strings lagged.

## What changed
- **Default model** → `doubao-seedance-2-0-260128` in `core/output.py` (`DEFAULT_MODEL`) and `core/config.py` (`SEEDANCE_DEFAULT_MODEL` env default).
- **`--generate-audio` help**: now "supported by `doubao-seedance-1-5-pro-251215` and the `doubao-seedance-2-0` series".
- **`seedance models` table + README**: moved the "(default)" marker to `2-0-260128`, refreshed the feature list and env-default docs.
- **Test** `tests/test_config.py`: default-model assertion updated.

`ruff` clean, `pytest` 56 passed / 1 skipped.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model). One round.

- RISK: `seedance models` table still marked 1.0-Pro "(default)" / 1.5-Pro "Newest". → **Fixed**: moved "(default)" to `2-0-260128`, relabelled 1.5-Pro "Newest 1.x".
- RISK: legacy non-2.0 models are still accepted by Click validation even though the worker rejects them. → **Rebut**: the 1.x models are still listed in the PlatformBackend OpenAPI model enum on `main` (the sync source of truth); removing them is a separate product/billing decision (flagged to the maintainer). This PR's scope is fixing the dead default, not deprecating 1.x — keeping them keeps the CLI consistent with the current OpenAPI.

VERDICT after fixes: CLEAN.
