### PR TITLE
chore(cli): rename AdcCli->AceDataCloudCli; confirm kling/webextrator/hailuo mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Monorepo for all AceDataCloud command-line interface tools.
 | `flux/` | [FluxCli](https://github.com/AceDataCloud/FluxCli) | Flux image generation & editing CLI |
 | `serp/` | [SerpCli](https://github.com/AceDataCloud/SerpCli) | Google SERP (Search) CLI |
 | `wan/` | [WanCli](https://github.com/AceDataCloud/WanCli) | Tongyi Wansiang video generation CLI |
-| `adc/` | [AdcCli](https://github.com/AceDataCloud/AdcCli) | Unified AceDataCloud CLI (all services) |
+| `adc/` | [AceDataCloudCli](https://github.com/AceDataCloud/AceDataCloudCli) | Unified AceDataCloud CLI (all services) |
 
 ## How It Works
 

--- a/adc/pyproject.toml
+++ b/adc/pyproject.toml
@@ -68,10 +68,10 @@ adc = "adc_cli.main:cli"
 adc-cli = "adc_cli.main:cli"
 
 [project.urls]
-Homepage = "https://github.com/AceDataCloud/AdcCli"
-Repository = "https://github.com/AceDataCloud/AdcCli"
-Issues = "https://github.com/AceDataCloud/AdcCli/issues"
-Changelog = "https://github.com/AceDataCloud/AdcCli/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/AceDataCloud/AceDataCloudCli"
+Repository = "https://github.com/AceDataCloud/AceDataCloudCli"
+Issues = "https://github.com/AceDataCloud/AceDataCloudCli/issues"
+Changelog = "https://github.com/AceDataCloud/AceDataCloudCli/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling>=1.21.0,<1.22.0"]

--- a/sync.yaml
+++ b/sync.yaml
@@ -50,7 +50,7 @@ mappings:
       - .github
       - .gitbooks
   adc:
-    repo: AceDataCloud/AdcCli
+    repo: AceDataCloud/AceDataCloudCli
     exclude:
       - .github
       - .gitbooks


### PR DESCRIPTION
## Goal
- (A) Map kling/webextrator/hailuo CLIs to subrepos — already present on main (KlingCli, WebExtratorCli, HailuoCli all exist; mappings in sync.yaml). PyPI 404s will clear once the cron publishes.
- (B) Rename adc subrepo AdcCli -> AceDataCloudCli everywhere. PyPI pkg acedatacloud-cli unchanged.

## Change
- sync.yaml: adc.repo AdcCli -> AceDataCloudCli.
- README.md + adc/pyproject.toml URLs -> AceDataCloudCli.
- Code class AdcClient / module adc_cli intentionally untouched (package name acedatacloud-cli).
- GitHub repo renamed AdcCli -> AceDataCloudCli (old slug redirects).

## 🤖 对抗评审
Codex (read-only): VERDICT: CLEAN. No broken refs; old standalone repo slug gone; AdcClient/adc_cli are intentional code/package names; AceDataCloudCli verified to exist with main branch + CHANGELOG.md.