### PR TITLE
test: conftest fixture 跟上 started_at/finished_at 的数值化

### DIFF
--- a/fish/tests/conftest.py
+++ b/fish/tests/conftest.py
@@ -39,7 +39,7 @@ def mock_tts_async_response():
     """Mock async TTS submission response."""
     return {
         "task_id": "2725a2d3-f87e-4905-9c53-9988d5a7b2f5",
-        "started_at": "2025-05-09T12:34:56.789Z",
+        "started_at": 1746794096.789,
     }
 
 

--- a/maestro/tests/conftest.py
+++ b/maestro/tests/conftest.py
@@ -54,8 +54,8 @@ def mock_task_done_response():
         "id": "maestro-task-123",
         "status": "succeeded",
         "created_at": "2025-01-21T00:00:00.000Z",
-        "started_at": "2025-01-21T00:00:05.000Z",
-        "finished_at": "2025-01-21T00:01:00.000Z",
+        "started_at": 1737417605.0,
+        "finished_at": 1737417660.0,
         "elapsed": 55,
         "response": {
             "data": {

--- a/openai/tests/conftest.py
+++ b/openai/tests/conftest.py
@@ -132,7 +132,7 @@ def mock_task_response():
         "type": "images_generations",
         "application_id": "9dec7b2a-1cad-41ff-8536-d4ddaf2525d4",
         "created_at": 1763142607.967,
-        "started_at": "2025-10-26T00:00:00.069+00:00",
+        "started_at": 1761436800.069,
         "finished_at": 1763142637.404,
         "elapsed": 29.437,
         "request": {

--- a/webextrator/tests/conftest.py
+++ b/webextrator/tests/conftest.py
@@ -9,8 +9,8 @@ def mock_extract_response() -> dict:
         "success": True,
         "task_id": "550e8400-e29b-41d4-a716-446655440000",
         "trace_id": "550e8400-e29b-41d4-a716-446655440001",
-        "started_at": "2025-05-02T10:30:00.123Z",
-        "finished_at": "2025-05-02T10:30:08.789Z",
+        "started_at": 1746181800.123,
+        "finished_at": 1746181808.789,
         "elapsed": 8.666,
         "data": {
             "kind": "extract",
@@ -28,8 +28,8 @@ def mock_render_response() -> dict:
         "success": True,
         "task_id": "550e8400-e29b-41d4-a716-446655440002",
         "trace_id": "550e8400-e29b-41d4-a716-446655440003",
-        "started_at": "2025-05-02T10:30:00.123Z",
-        "finished_at": "2025-05-02T10:30:05.456Z",
+        "started_at": 1746181800.123,
+        "finished_at": 1746181805.456,
         "elapsed": 5.333,
         "data": {
             "kind": "render",
@@ -49,7 +49,7 @@ def mock_task_response() -> dict:
         "task_id": "550e8400-e29b-41d4-a716-446655440000",
         "trace_id": "550e8400-e29b-41d4-a716-446655440001",
         "type": "extract",
-        "started_at": "2025-05-02T10:30:00.123Z",
-        "finished_at": "2025-05-02T10:30:08.789Z",
+        "started_at": 1746181800.123,
+        "finished_at": 1746181808.789,
         "elapsed": 8.666,
     }


### PR DESCRIPTION
跟随平台的计时字段统一（[PlatformService#1778](https://github.com/AceDataCloud/PlatformService/pull/1778)）。

fish / maestro / openai / webextrator 四个 CLI 的 `conftest.py` fixture 仍用 ISO 字符串模拟响应。

31 / 28 / 86 / 21 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)