### PR TITLE
style: ruff format —— 自动同步写入的代码一直没过格式检查

### DIFF
--- a/fish/fish_cli/core/client.py
+++ b/fish/fish_cli/core/client.py
@@ -24,8 +24,7 @@ class FishClient:
         """Get request headers with authentication."""
         if not self.api_token:
             raise FishAuthError(
-                "API token not configured. "
-                "Set ACEDATACLOUD_API_TOKEN or use --token option."
+                "API token not configured. Set ACEDATACLOUD_API_TOKEN or use --token option."
             )
         headers = {
             "accept": "application/json",

--- a/fish/tests/test_commands.py
+++ b/fish/tests/test_commands.py
@@ -62,9 +62,7 @@ class TestTTSCommand:
         respx.post("https://api.acedata.cloud/fish/tts").mock(
             return_value=Response(200, json=mock_tts_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "tts", "Hello, world!", "--json"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "tts", "Hello, world!", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert "audio_url" in data
@@ -226,9 +224,7 @@ class TestTTSCommand:
         route = respx.post("https://api.acedata.cloud/fish/tts").mock(
             return_value=Response(200, json=mock_tts_async_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "tts", "Hello", "--async", "--json"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "tts", "Hello", "--async", "--json"])
         assert result.exit_code == 0
         sent = json.loads(route.calls[0].request.content)
         assert sent["async"] is True
@@ -238,9 +234,7 @@ class TestTTSCommand:
         respx.post("https://api.acedata.cloud/fish/tts").mock(
             return_value=Response(200, json=mock_tts_async_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "tts", "Hello", "--async"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "tts", "Hello", "--async"])
         assert result.exit_code == 0
         assert "2725a2d3" in result.output
 


### PR DESCRIPTION
CI 的 Lint job 一直是红的，失败文件的最后改动都是 `sync: update from Docs [automated]` —— **同步机器人写入的代码不过 `ruff format --check`**，于是 CI 从那时起就红着。

不是某个 PR 引入的，也不是我这轮改的（我只碰了测试 fixture）。先把存量修平。

> **根因未修**：同步链路缺一道格式化。建议在同步 workflow 里加 `ruff format` 再提交，否则下次同步会再红一次。

`ruff check` / `ruff format --check` / 全部测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)