### PR TITLE
fix(gemini): drop image models from the chat model list

### DIFF
--- a/gemini/README.md
+++ b/gemini/README.md
@@ -49,13 +49,14 @@ gemini models
 | `gemini-3.5-flash` | Gemini 3.5 Flash |
 | `gemini-3-flash-preview` | Gemini 3 Flash Preview |
 | `gemini-3.1-flash-lite-preview` | Gemini 3.1 Flash Lite Preview |
-| `gemini-3.1-flash-image` | Gemini 3.1 Flash Image |
-| `gemini-3-pro-image` | Gemini 3 Pro Image |
 | `gemini-2.5-pro` | Gemini 2.5 Pro |
 | `gemini-2.5-flash` | Gemini 2.5 Flash (default) |
 | `gemini-2.5-flash-lite` | Gemini 2.5 Flash Lite |
-| `gemini-2.5-flash-image` | Gemini 2.5 Flash Image |
 | `gemini-2.0-flash` | Gemini 2.0 Flash |
+
+> Image-generating models (`gemini-*-image`) are not available on the chat
+> endpoint. Use the native `/v1beta/models/{model}:generateContent` API for
+> image generation.
 
 ## Available Video Models
 

--- a/gemini/gemini_cli/core/output.py
+++ b/gemini/gemini_cli/core/output.py
@@ -17,12 +17,9 @@ GEMINI_CHAT_MODELS = [
     "gemini-3.5-flash",
     "gemini-3-flash-preview",
     "gemini-3.1-flash-lite-preview",
-    "gemini-3.1-flash-image",
-    "gemini-3-pro-image",
     "gemini-2.5-pro",
     "gemini-2.5-flash",
     "gemini-2.5-flash-lite",
-    "gemini-2.5-flash-image",
     "gemini-2.0-flash",
 ]
 

--- a/gemini/tests/test_commands.py
+++ b/gemini/tests/test_commands.py
@@ -98,9 +98,6 @@ class TestChatCommand:
         for model in [
             "gemini-2.5-flash-lite",
             "gemini-3.1-flash-lite-preview",
-            "gemini-3.1-flash-image",
-            "gemini-2.5-flash-image",
-            "gemini-3-pro-image",
         ]:
             respx.post("https://api.acedata.cloud/gemini/chat/completions").mock(
                 return_value=Response(200, json=mock_chat_response)
@@ -109,6 +106,18 @@ class TestChatCommand:
                 cli, ["--token", "test-token", "chat", "Hello", "-m", model, "--json"]
             )
             assert result.exit_code == 0, f"Model {model} failed: {result.output}"
+
+    def test_chat_rejects_image_models(self, runner):
+        """Image models are native-only; the chat endpoint can't serve them."""
+        for model in [
+            "gemini-3.1-flash-image",
+            "gemini-2.5-flash-image",
+            "gemini-3-pro-image",
+        ]:
+            result = runner.invoke(
+                cli, ["--token", "test-token", "chat", "Hello", "-m", model, "--json"]
+            )
+            assert result.exit_code != 0, f"Model {model} should be rejected"
 
     @respx.mock
     def test_chat_with_max_completion_tokens(self, runner, mock_chat_response):


### PR DESCRIPTION
## 背景

配套 [PlatformBackend#1286](https://github.com/AceDataCloud/PlatformBackend/pull/1286)。

`/gemini/chat/completions` 上的三个图像模型**没有任何上游能服务**——账号池里全部 Gemini image capability 都是 `native: true`，只认 Gemini 原生 body（`contents`）。CLI 发的是 OpenAI 形状（`messages`），上游返回 `contents is required`，候选耗尽后变 503。

## 改动

| 文件 | 改动 |
|---|---|
| `core/output.py` | `GEMINI_CHAT_MODELS` 12 → 9 |
| `README.md` | 模型表同步，加一句指向原生 API |
| `tests/test_commands.py` | 改断言 + 加守卫测试 |

`chat.py` 用的是 `click.Choice(GEMINI_CHAT_MODELS)`，所以摘掉后 CLI 会**在本地直接拒绝**，不再发一个注定失败的请求出去。

## 测试

`test_chat_with_new_models` 原本断言三个 image 模型返回 0，现在必然失败——把它翻转成 `test_chat_rejects_image_models`，断言被拒绝，把这个契约锁住。

```
32 passed
```

`ruff check` 通过。`ruff format --check` 报的 4 个文件（`chat.py` / `client.py` 等）是本 PR **未触碰**的既存漂移，归 `fix/ruff-format-drift`。

## 用户影响

图像生成改走原生 `/v1beta/models/{model}:generateContent`（健康度 92–99.7%）。CLI 目前不封装该端点——如需 CLI 侧支持可另开 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)