### PR TITLE
Remove unavailable Seedream 3.0 CLI models

### DIFF
--- a/seedream/README.md
+++ b/seedream/README.md
@@ -14,7 +14,7 @@ Generate AI images directly from your terminal — no MCP client required.
 
 - **Image Generation** — Generate images from text prompts with multiple models
 - **Image Editing** — Edit, combine, and transform images with AI
-- **Multiple Models** — doubao-seedream-5-0-pro-260628, doubao-seedream-5-0-260128, doubao-seedream-4-5-251128, doubao-seedream-4-0-250828, doubao-seedream-3-0-t2i-250415, doubao-seededit-3-0-i2i-250628
+- **Multiple Models** — doubao-seedream-5-0-pro-260628, doubao-seedream-5-0-260128, doubao-seedream-4-5-251128, doubao-seedream-4-0-250828
 - **Task Management** — Query tasks, batch query, wait with polling
 - **Rich Output** — Beautiful terminal tables and panels via Rich
 - **JSON Mode** — Machine-readable output with `--json` for piping
@@ -111,8 +111,6 @@ Most commands support:
 | `doubao-seedream-5-0-260128` | V5.0 | Latest model (default) |
 | `doubao-seedream-4-5-251128` | V4.5 | Flagship model, best quality |
 | `doubao-seedream-4-0-250828` | V4.0 | Standard quality |
-| `doubao-seedream-3-0-t2i-250415` | V3.0 T2I | Text-to-image generation |
-| `doubao-seededit-3-0-i2i-250628` | V3.0 I2I | Image-to-image editing |
 
 
 ## Configuration

--- a/seedream/seedream_cli/core/output.py
+++ b/seedream/seedream_cli/core/output.py
@@ -15,8 +15,6 @@ SEEDREAM_MODELS = [
     "doubao-seedream-5-0-260128",
     "doubao-seedream-4-5-251128",
     "doubao-seedream-4-0-250828",
-    "doubao-seedream-3-0-t2i-250415",
-    "doubao-seededit-3-0-i2i-250628",
 ]
 
 DEFAULT_MODEL = "doubao-seedream-5-0-260128"
@@ -134,16 +132,5 @@ def print_models() -> None:
         "V4.0",
         "Standard quality",
     )
-    table.add_row(
-        "doubao-seedream-3-0-t2i-250415",
-        "V3.0 T2I",
-        "Text-to-image generation",
-    )
-    table.add_row(
-        "doubao-seededit-3-0-i2i-250628",
-        "V3.0 I2I",
-        "Image-to-image editing",
-    )
-
     console.print(table)
     console.print(f"\n[dim]Default model: {DEFAULT_MODEL}[/dim]")

--- a/seedream/tests/test_output.py
+++ b/seedream/tests/test_output.py
@@ -17,7 +17,7 @@ class TestConstants:
     """Tests for output constants."""
 
     def test_models_count(self):
-        assert len(SEEDREAM_MODELS) == 6
+        assert len(SEEDREAM_MODELS) == 4
 
     def test_default_model_in_models(self):
         assert DEFAULT_MODEL in SEEDREAM_MODELS
@@ -28,10 +28,12 @@ class TestConstants:
             "doubao-seedream-5-0-260128",
             "doubao-seedream-4-5-251128",
             "doubao-seedream-4-0-250828",
-            "doubao-seedream-3-0-t2i-250415",
-            "doubao-seededit-3-0-i2i-250628",
         ]:
             assert model in SEEDREAM_MODELS
+
+    def test_models_exclude_unavailable_v3_models(self):
+        assert "doubao-seedream-3-0-t2i-250415" not in SEEDREAM_MODELS
+        assert "doubao-seededit-3-0-i2i-250628" not in SEEDREAM_MODELS
 
     def test_resolutions(self):
         assert len(RESOLUTIONS) == 5


### PR DESCRIPTION
## Summary
- remove unavailable Seedream 3.0 T2I and SeedEdit 3.0 from the CLI model list
- update rendered model help and README
- add regression assertions that retired models stay excluded

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_output.py` (14 passed)
- `ruff check seedream/seedream_cli/core/output.py seedream/tests/test_output.py`
- `git diff --check`

## Dependency / rollout
Downstream client sync for PlatformService / PlatformBackend Seedream v3 withdrawal.

Rollback: revert this commit.