### PR TITLE
fix(hailuo): remove watermark CLI option

### DIFF
--- a/hailuo/hailuo_cli/commands/video.py
+++ b/hailuo/hailuo_cli/commands/video.py
@@ -120,9 +120,7 @@ def generate(
     client = get_client(ctx.obj.get("token"))
     try:
         if not prompt and not image_urls and not video_urls and not audio_urls:
-            raise click.UsageError(
-                "Provide PROMPT or at least one media URL input."
-            )
+            raise click.UsageError("Provide PROMPT or at least one media URL input.")
         if prompt and len(prompt) > 7000:
             raise click.UsageError("PROMPT must be at most 7000 characters.")
         content: list[dict[str, object]] = []

--- a/hailuo/hailuo_cli/commands/video.py
+++ b/hailuo/hailuo_cli/commands/video.py
@@ -89,12 +89,6 @@ CONTENT_ROLE_CHOICES = [
     show_default=True,
     help="Output resolution.",
 )
-@click.option(
-    "--aigc-watermark/--no-aigc-watermark",
-    default=False,
-    show_default=True,
-    help="Whether to enable AIGC watermark.",
-)
 @click.option("--callback-url", default=None, help="Webhook callback URL.")
 @click.option("--json", "output_json", is_flag=True, help="Output raw JSON.")
 @click.pass_context
@@ -111,7 +105,6 @@ def generate(
     ratio: str,
     duration: int,
     resolution: str,
-    aigc_watermark: bool,
     callback_url: str | None,
     output_json: bool,
 ) -> None:
@@ -157,7 +150,6 @@ def generate(
             "resolution": resolution,
             "ratio": ratio,
             "duration": duration,
-            "aigc_watermark": aigc_watermark,
             "callback_url": callback_url,
         }
 
@@ -202,12 +194,6 @@ def generate(
     show_default=True,
     help="Output resolution.",
 )
-@click.option(
-    "--aigc-watermark/--no-aigc-watermark",
-    default=False,
-    show_default=True,
-    help="Whether to enable AIGC watermark.",
-)
 @click.option("--callback-url", default=None, help="Webhook callback URL.")
 @click.option("--json", "output_json", is_flag=True, help="Output raw JSON.")
 @click.pass_context
@@ -219,7 +205,6 @@ def image_to_video(
     ratio: str,
     duration: int,
     resolution: str,
-    aigc_watermark: bool,
     callback_url: str | None,
     output_json: bool,
 ) -> None:
@@ -247,7 +232,6 @@ def image_to_video(
             "resolution": resolution,
             "ratio": ratio,
             "duration": duration,
-            "aigc_watermark": aigc_watermark,
             "callback_url": callback_url,
         }
 

--- a/hailuo/hailuo_cli/core/output.py
+++ b/hailuo/hailuo_cli/core/output.py
@@ -55,6 +55,7 @@ def print_video_result(data: dict[str, Any]) -> None:
 
 def print_task_result(data: dict[str, Any]) -> None:
     """Print task query result in a rich format."""
+
     def print_task(task_data: dict[str, Any]) -> None:
         table = Table(show_header=False, box=None, padding=(0, 2))
         table.add_column("Field", style="bold cyan", width=15)

--- a/hailuo/tests/test_commands.py
+++ b/hailuo/tests/test_commands.py
@@ -140,7 +140,7 @@ class TestGenerateCommands:
         ]
 
     @respx.mock
-    def test_generate_with_resolution_and_watermark(self, mock_video_response):
+    def test_generate_with_resolution(self, mock_video_response):
         runner = CliRunner()
         route = respx.post("https://api.acedata.cloud/minimax/videos").mock(
             return_value=Response(200, json=mock_video_response)
@@ -154,14 +154,22 @@ class TestGenerateCommands:
                 "A test prompt",
                 "--resolution",
                 "768P",
-                "--aigc-watermark",
                 "--json",
             ],
         )
         assert result.exit_code == 0
         sent = json.loads(route.calls[0].request.content)
         assert sent["resolution"] == "768P"
-        assert sent["aigc_watermark"] is True
+        assert "aigc_watermark" not in sent
+
+    def test_generate_rejects_removed_watermark_flag(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--token", "test-token", "generate", "A test prompt", "--aigc-watermark"],
+        )
+        assert result.exit_code != 0
+        assert "No such option: --aigc-watermark" in result.output
 
     def test_generate_requires_any_input(self):
         runner = CliRunner()
@@ -251,7 +259,7 @@ class TestGenerateCommands:
         assert sent["model"] == "MiniMax-H3"
 
     @respx.mock
-    def test_image_to_video_with_resolution_and_watermark(self, mock_video_response):
+    def test_image_to_video_with_resolution(self, mock_video_response):
         runner = CliRunner()
         route = respx.post("https://api.acedata.cloud/minimax/videos").mock(
             return_value=Response(200, json=mock_video_response)
@@ -267,14 +275,13 @@ class TestGenerateCommands:
                 "https://example.com/photo.jpg",
                 "--resolution",
                 "768P",
-                "--aigc-watermark",
                 "--json",
             ],
         )
         assert result.exit_code == 0
         sent = json.loads(route.calls[0].request.content)
         assert sent["resolution"] == "768P"
-        assert sent["aigc_watermark"] is True
+        assert "aigc_watermark" not in sent
 
 
 class TestTaskCommands:

--- a/hailuo/tests/test_commands.py
+++ b/hailuo/tests/test_commands.py
@@ -169,7 +169,8 @@ class TestGenerateCommands:
             ["--token", "test-token", "generate", "A test prompt", "--aigc-watermark"],
         )
         assert result.exit_code != 0
-        assert "No such option: --aigc-watermark" in result.output
+        assert "No such option" in result.output
+        assert "--aigc-watermark" in result.output
 
     def test_generate_requires_any_input(self):
         runner = CliRunner()


### PR DESCRIPTION
## Contract

`POST /minimax/videos` (API `64f22fd9-0efd-445e-b0b1-135682fd66d7`) no longer exposes `aigc_watermark`. After the coordinated runtime change, explicitly sending either boolean value is rejected as an unsupported field (HTTP 400), rather than silently ignored.

## Changes and validation

Removes the boolean flag from both MiniMax-backed Hailuo CLI commands and removes the emitted payload key. Adds a negative test proving the retired flag is rejected across Click versions.

Validation:
- local ruff passed
- local command tests: 24 passed
- CI lint, build, and tests on Python 3.10/3.11/3.12 are all green

## Dependency graph

consumer surfaces → PlatformService runtime enforcement + PlatformBackend OpenAPI/docs → generated Docs/downstream reconciliation

This consumer removal is safe to merge before the runtime/contract switch because it only stops emitting an optional field whose existing default is already `false`.

## Rollout / rollback

Release before or with the PlatformService and PlatformBackend PRs. Roll back together with the coordinated set; do not restore the parameter in only one surface.

## Out of scope

Legacy `/hailuo/videos`, billing rules, generated Docs files, and historical validation reports.

Adversarial review: not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
