### PR TITLE
feat(maestro): expose production SKU contract

### DIFF
--- a/maestro/README.md
+++ b/maestro/README.md
@@ -17,3 +17,13 @@ maestro create "Continue the story" --action extend --ref-task-id <task-id>
 maestro task <task-id>
 maestro wait <task-id>
 ```
+
+## Production SKUs
+
+| SKU | Price | Duration | Output | Languages | Capabilities |
+|---|---:|---:|---|---:|---|
+| `lite` | 0.20 Credits/second | 5–30s | 720p/24fps | 1 | auto/narrated/captions; generate/edit |
+| `standard` | 0.60 Credits/second | 5–120s | 1080p/30fps | 2 | adds avatar and remix |
+| `pro` | 1.20 Credits/second | 5–300s | 1080p/30fps | 4 | adds drama and extend |
+
+Successful tasks are billed by delivered integer-second duration, with no 30-second minimum. Avatar uses a 1.15× multiplier, drama uses 1.35×, and each additional delivered language adds 6 Credits. Failed tasks and polling are free.

--- a/maestro/maestro_cli/commands/video.py
+++ b/maestro/maestro_cli/commands/video.py
@@ -16,6 +16,7 @@ from maestro_cli.core.output import (
     MAESTRO_ACTIONS,
     QUALITY_TIERS,
     SCENARIOS,
+    SKU_LIMITS,
     print_error,
     print_json,
     print_video_result,
@@ -63,21 +64,21 @@ from maestro_cli.core.output import (
     type=click.IntRange(5, 300),
     default=DEFAULT_DURATION,
     show_default=True,
-    help="Target video length in seconds (5-300).",
+    help="Target video length in seconds (5-300; SKU-specific maximums apply).",
 )
 @click.option(
     "--quality",
     type=click.Choice(QUALITY_TIERS),
     default=DEFAULT_QUALITY,
     show_default=True,
-    help="Production tier: lite (720p), standard (1080p), or pro (advanced production).",
+    help="Production SKU: lite (720p, up to 30s), standard (1080p, up to 120s), pro (up to 300s).",
 )
 @click.option(
     "--scenario",
     type=click.Choice(SCENARIOS),
     default=DEFAULT_SCENARIO,
     show_default=True,
-    help="Production route: auto, narrated, captions, avatar, or drama.",
+    help="Production workflow: auto/narrated/captions/avatar/drama (SKU-specific availability applies).",
 )
 @click.option(
     "--style",
@@ -125,8 +126,15 @@ def create(
     """
     if action != "generate" and not ref_task_id:
         raise click.UsageError("--ref-task-id is required for remix, edit, and extend actions.")
-    if len(langs) > 4:
-        raise click.UsageError("At most four --lang options may be specified.")
+    limits = SKU_LIMITS[quality]
+    if duration > limits["duration"]:
+        raise click.UsageError(f"{quality} supports at most {limits['duration']} seconds")
+    if langs and len(langs) > limits["languages"]:
+        raise click.UsageError(f"{quality} supports at most {limits['languages']} language(s)")
+    if action not in limits["actions"]:
+        raise click.UsageError(f"action={action} requires a higher Maestro SKU")
+    if scenario not in limits["scenarios"]:
+        raise click.UsageError(f"scenario={scenario} requires a higher Maestro SKU")
 
     client = get_client(ctx.obj.get("token"))
 

--- a/maestro/maestro_cli/core/output.py
+++ b/maestro/maestro_cli/core/output.py
@@ -1,7 +1,7 @@
 """Rich terminal output formatting for Maestro CLI."""
 
 import json
-from typing import Any
+from typing import Any, TypedDict
 
 import click
 from rich.console import Console
@@ -29,12 +29,41 @@ ASPECT_RATIOS = [
 
 DEFAULT_ASPECT_RATIO = "9:16"
 
+
+class SkuLimits(TypedDict):
+    duration: int
+    languages: int
+    actions: set[str]
+    scenarios: set[str]
+
+
 # Available quality tiers
 QUALITY_TIERS = [
     "lite",
     "standard",
     "pro",
 ]
+
+SKU_LIMITS: dict[str, SkuLimits] = {
+    "lite": {
+        "duration": 30,
+        "languages": 1,
+        "actions": {"generate", "edit"},
+        "scenarios": {"auto", "narrated", "captions"},
+    },
+    "standard": {
+        "duration": 120,
+        "languages": 2,
+        "actions": {"generate", "remix", "edit"},
+        "scenarios": {"auto", "narrated", "captions", "avatar"},
+    },
+    "pro": {
+        "duration": 300,
+        "languages": 4,
+        "actions": {"generate", "remix", "edit", "extend"},
+        "scenarios": {"auto", "narrated", "captions", "avatar", "drama"},
+    },
+}
 
 DEFAULT_QUALITY = "standard"
 
@@ -191,9 +220,9 @@ def print_models() -> None:
     scenario_notes = {
         "auto": "AI director chooses from your brief (default)",
         "narrated": "Multi-scene narrated video with real photos + voiceover",
-        "captions": "Caption an existing source video",
-        "avatar": "Talking-head / digital human (1.15×)",
-        "drama": "Acted short drama with characters + dialogue (1.35×)",
+        "captions": "Kinetic captions for an uploaded source video",
+        "avatar": "Talking-head / digital human (Standard or Pro, 1.15×)",
+        "drama": "Acted short drama (Pro only, 1.35×)",
     }
     for scenario, note in scenario_notes.items():
         table.add_row(scenario, note)

--- a/maestro/tests/test_commands.py
+++ b/maestro/tests/test_commands.py
@@ -69,9 +69,7 @@ class TestCreateCommand:
         respx.post("https://api.acedata.cloud/maestro/videos").mock(
             return_value=Response(200, json=mock_video_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "create", "A product demo video"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "create", "A product demo video"])
         assert result.exit_code == 0
         assert "maestro-task-123" in result.output
 
@@ -154,6 +152,30 @@ class TestCreateCommand:
         assert result.exit_code == 0
         sent = json.loads(route.calls[0].request.content)
         assert sent["scenario"] == "captions"
+
+    @respx.mock
+    def test_sku_limits_fail_before_api_call(self, runner):
+        route = respx.post("https://api.acedata.cloud/maestro/videos")
+        lite = runner.invoke(
+            cli,
+            ["--token", "test-token", "create", "test", "--quality", "lite", "--duration", "31"],
+        )
+        drama = runner.invoke(
+            cli,
+            [
+                "--token",
+                "test-token",
+                "create",
+                "test",
+                "--quality",
+                "standard",
+                "--scenario",
+                "drama",
+            ],
+        )
+        assert lite.exit_code != 0 and "at most 30 seconds" in lite.output
+        assert drama.exit_code != 0 and "higher Maestro SKU" in drama.output
+        assert not route.called
 
     @respx.mock
     def test_create_with_style(self, runner, mock_video_response):
@@ -269,6 +291,8 @@ class TestCreateCommand:
                 "continue the story",
                 "--action",
                 "extend",
+                "--quality",
+                "pro",
                 "--ref-task-id",
                 "prev-task-id",
                 "--json",
@@ -389,7 +413,7 @@ class TestCreateCommand:
             ],
         )
         assert result.exit_code != 0
-        assert "At most four --lang" in result.output
+        assert "standard supports at most 2 language(s)" in result.output
 
     @respx.mock
     def test_create_api_error(self, runner, mock_error_response):


### PR DESCRIPTION
## Contract
Align `maestro-cli` choices, help, examples, and local validation with Lite / Standard / Pro. Invalid cross-SKU duration/language/action/scenario combinations now fail before an API call.

Customer pricing remains actual delivered integer seconds with no 30-second minimum.

## Validation
- ruff passed
- mypy passed
- pytest: 31 passed

Depends only on the already-live core Maestro contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)