### PR TITLE
fix: use owned PyPI names for chat CLIs

### DIFF
--- a/aichat/README.md
+++ b/aichat/README.md
@@ -14,7 +14,7 @@ A command-line tool for AI Dialogue via the [AceDataCloud](https://platform.aced
 ## Installation
 
 ```bash
-pip install aichat-cli
+pip install aichat-pro-cli
 ```
 
 ## Quick Start

--- a/aichat/aichat_cli/main.py
+++ b/aichat/aichat_cli/main.py
@@ -20,7 +20,7 @@ load_dotenv()
 def get_version() -> str:
     """Get the package version."""
     try:
-        return metadata.version("aichat-cli")
+        return metadata.version("aichat-pro-cli")
     except metadata.PackageNotFoundError:
         return "dev"
 

--- a/aichat/pyproject.toml
+++ b/aichat/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "aichat-cli"
+name = "aichat-pro-cli"
 version = "0.1.0"
 description = "CLI tool for AI Dialogue (aichat) via AceDataCloud API"
 readme = "README.md"
@@ -58,7 +58,7 @@ release = [
     "twine>=6.1.0",
 ]
 all = [
-    "aichat-cli[dev,test,release]",
+    "aichat-pro-cli[dev,test,release]",
 ]
 
 [project.scripts]

--- a/aichat/tests/test_commands.py
+++ b/aichat/tests/test_commands.py
@@ -7,7 +7,7 @@ import respx
 from click.testing import CliRunner
 from httpx import Response
 
-from aichat_cli.main import cli
+from aichat_cli.main import cli, get_version
 
 
 @pytest.fixture
@@ -25,6 +25,14 @@ class TestGlobalCommands:
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert "aichat-cli" in result.output
+
+    def test_version_uses_distribution_name(self, monkeypatch):
+        monkeypatch.setattr(
+            "aichat_cli.main.metadata.version",
+            lambda name: "1.2.3" if name == "aichat-pro-cli" else None,
+        )
+
+        assert get_version() == "1.2.3"
 
     def test_help(self, runner):
         result = runner.invoke(cli, ["--help"])

--- a/openai/README.md
+++ b/openai/README.md
@@ -5,7 +5,7 @@ A command-line tool for OpenAI-compatible APIs via [AceDataCloud](https://platfo
 ## Installation
 
 ```bash
-pip install openai-cli
+pip install openai-pro-cli
 ```
 
 ## Quick Start

--- a/openai/openai_cli/commands/chat.py
+++ b/openai/openai_cli/commands/chat.py
@@ -137,7 +137,9 @@ from openai_cli.core.output import (
     flag_value=False,
     help="Disable parallel function calling during tool use.",
 )
-@click.option("--stream", is_flag=True, default=False, help="Stream partial chat completion events.")
+@click.option(
+    "--stream", is_flag=True, default=False, help="Stream partial chat completion events."
+)
 @click.option(
     "--response-format",
     default=None,
@@ -156,37 +158,37 @@ from openai_cli.core.output import (
 @click.option(
     "--stream-options",
     default=None,
-    help='Streaming options as a JSON object (e.g. \'{"include_usage": true}\').',
+    help="Streaming options as a JSON object (e.g. '{\"include_usage\": true}').",
 )
 @click.option(
     "--metadata",
     default=None,
-    help='Metadata as a JSON object.',
+    help="Metadata as a JSON object.",
 )
 @click.option(
     "--logit-bias",
     default=None,
-    help='Logit bias map as a JSON object.',
+    help="Logit bias map as a JSON object.",
 )
 @click.option(
     "--modalities",
     default=None,
-    help='Requested modalities as a JSON array.',
+    help="Requested modalities as a JSON array.",
 )
 @click.option(
     "--audio",
     default=None,
-    help='Audio output settings as a JSON object.',
+    help="Audio output settings as a JSON object.",
 )
 @click.option(
     "--prediction",
     default=None,
-    help='Prediction settings as a JSON object.',
+    help="Prediction settings as a JSON object.",
 )
 @click.option(
     "--web-search-options",
     default=None,
-    help='Web search settings as a JSON object.',
+    help="Web search settings as a JSON object.",
 )
 @click.option("--json", "output_json", is_flag=True, help="Output raw JSON.")
 @click.pass_context
@@ -252,9 +254,7 @@ def chat(
         parsed_modalities = parse_json_array(modalities, "--modalities")
         parsed_audio = parse_json_object(audio, "--audio")
         parsed_prediction = parse_json_object(prediction, "--prediction")
-        parsed_web_search_options = parse_json_object(
-            web_search_options, "--web-search-options"
-        )
+        parsed_web_search_options = parse_json_object(web_search_options, "--web-search-options")
     except click.BadParameter as e:
         print_error(e.format_message())
         raise SystemExit(1) from None

--- a/openai/openai_cli/commands/transcribe.py
+++ b/openai/openai_cli/commands/transcribe.py
@@ -103,7 +103,9 @@ def transcribe(
         "keywords": list(keywords) if keywords else None,
         "response_format": response_format,
         "temperature": temperature,
-        "timestamp_granularities": list(timestamp_granularities) if timestamp_granularities else None,
+        "timestamp_granularities": list(timestamp_granularities)
+        if timestamp_granularities
+        else None,
         "stream": stream or None,
     }
 

--- a/openai/openai_cli/main.py
+++ b/openai/openai_cli/main.py
@@ -27,7 +27,7 @@ load_dotenv()
 def get_version() -> str:
     """Get the package version."""
     try:
-        return metadata.version("openai-cli")
+        return metadata.version("openai-pro-cli")
     except metadata.PackageNotFoundError:
         return "dev"
 

--- a/openai/pyproject.toml
+++ b/openai/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "openai-cli"
+name = "openai-pro-cli"
 version = "0.1.0"
 description = "CLI tool for OpenAI-compatible APIs via AceDataCloud"
 readme = "README.md"
@@ -58,7 +58,7 @@ release = [
     "twine>=6.1.0",
 ]
 all = [
-    "openai-cli[dev,test,release]",
+    "openai-pro-cli[dev,test,release]",
 ]
 
 [project.scripts]

--- a/openai/tests/test_client.py
+++ b/openai/tests/test_client.py
@@ -121,13 +121,22 @@ class TestOpenAIClient:
                 messages=[{"role": "user", "content": "Hi"}],
             )
 
-
     @respx.mock
     def test_models_request(self):
         route = respx.get("https://api.acedata.cloud/openai/models").mock(
             return_value=Response(
                 200,
-                json={"object": "list", "data": [{"id": "gpt-4o", "object": "model", "created": 1714500000, "owned_by": "system"}]},
+                json={
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "gpt-4o",
+                            "object": "model",
+                            "created": 1714500000,
+                            "owned_by": "system",
+                        }
+                    ],
+                },
             )
         )
         client = OpenAIClient(api_token="test-token")

--- a/openai/tests/test_commands.py
+++ b/openai/tests/test_commands.py
@@ -7,7 +7,7 @@ import respx
 from click.testing import CliRunner
 from httpx import Response
 
-from openai_cli.main import cli
+from openai_cli.main import cli, get_version
 
 
 @pytest.fixture
@@ -25,6 +25,14 @@ class TestGlobalCommands:
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert "openai-cli" in result.output
+
+    def test_version_uses_distribution_name(self, monkeypatch):
+        monkeypatch.setattr(
+            "openai_cli.main.metadata.version",
+            lambda name: "1.2.3" if name == "openai-pro-cli" else None,
+        )
+
+        assert get_version() == "1.2.3"
 
     def test_help(self, runner):
         result = runner.invoke(cli, ["--help"])

--- a/openai/tests/test_commands.py
+++ b/openai/tests/test_commands.py
@@ -723,8 +723,7 @@ class TestSpeechAndRealtimeCommands:
         assert data["model"] == "gpt-realtime-2.1"
         assert data["voice"] == "alloy"
         assert (
-            data["url"]
-            == "wss://api.acedata.cloud/v1/realtime?model=gpt-realtime-2.1&voice=alloy"
+            data["url"] == "wss://api.acedata.cloud/v1/realtime?model=gpt-realtime-2.1&voice=alloy"
         )
 
     def test_realtime_accepts_new_mini_model(self, runner):
@@ -895,8 +894,18 @@ class TestInfoCommands:
                 json={
                     "object": "list",
                     "data": [
-                        {"id": "gpt-5.4", "object": "model", "created": 1714500000, "owned_by": "system"},
-                        {"id": "gpt-4o", "object": "model", "created": 1714500000, "owned_by": "system"},
+                        {
+                            "id": "gpt-5.4",
+                            "object": "model",
+                            "created": 1714500000,
+                            "owned_by": "system",
+                        },
+                        {
+                            "id": "gpt-4o",
+                            "object": "model",
+                            "created": 1714500000,
+                            "owned_by": "system",
+                        },
                     ],
                 },
             )
@@ -914,7 +923,12 @@ class TestInfoCommands:
                 json={
                     "object": "list",
                     "data": [
-                        {"id": "gpt-5.4", "object": "model", "created": 1714500000, "owned_by": "system"}
+                        {
+                            "id": "gpt-5.4",
+                            "object": "model",
+                            "created": 1714500000,
+                            "owned_by": "system",
+                        }
                     ],
                 },
             )


### PR DESCRIPTION
## Summary
- publish AiChat CLI as `aichat-pro-cli` because `aichat-cli` belongs to an unrelated PyPI project
- publish OpenAI CLI as `openai-pro-cli` because `openai-cli` belongs to an unrelated PyPI project
- preserve all existing command names and add version lookup regression coverage
- leave `glm-cli` unchanged pending a separate PyPI ownership/permission check
- format the four pre-existing OpenAI files required by the monorepo CI gate

## Verification
- AiChat: 58 tests passed; `ruff check`, format check, build, and `twine check` passed
- OpenAI: 92 tests passed (1 integration test deselected); `ruff check`, format check, build, and `twine check` passed
- source files match the corresponding mirror repository PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)