### PR TITLE
fix: use glm-pro-cli PyPI package

### DIFF
--- a/glm/README.md
+++ b/glm/README.md
@@ -5,7 +5,7 @@ A command-line tool for GLM chat completions via [AceDataCloud](https://platform
 ## Installation
 
 ```bash
-pip install glm-cli
+pip install glm-pro-cli
 ```
 
 ## Quick Start

--- a/glm/glm_cli/commands/chat.py
+++ b/glm/glm_cli/commands/chat.py
@@ -130,7 +130,9 @@ from glm_cli.core.output import (
     default=False,
     help="Enable parallel function calling during tool use.",
 )
-@click.option("--stream", is_flag=True, default=False, help="Stream partial chat completion events.")
+@click.option(
+    "--stream", is_flag=True, default=False, help="Stream partial chat completion events."
+)
 @click.option(
     "--response-format",
     default=None,
@@ -149,7 +151,7 @@ from glm_cli.core.output import (
 @click.option(
     "--stream-options",
     default=None,
-    help='Streaming options as a JSON object (e.g. \'{"include_usage": true}\').',
+    help="Streaming options as a JSON object (e.g. '{\"include_usage\": true}').",
 )
 @click.option("--metadata", default=None, help="Metadata as a JSON object.")
 @click.option("--logit-bias", default=None, help="Logit bias map as a JSON object.")
@@ -220,9 +222,7 @@ def chat(
         parsed_modalities = parse_json_array(modalities, "--modalities")
         parsed_audio = parse_json_object(audio, "--audio")
         parsed_prediction = parse_json_object(prediction, "--prediction")
-        parsed_web_search_options = parse_json_object(
-            web_search_options, "--web-search-options"
-        )
+        parsed_web_search_options = parse_json_object(web_search_options, "--web-search-options")
     except click.BadParameter as e:
         print_error(e.format_message())
         raise SystemExit(1) from None

--- a/glm/glm_cli/core/client.py
+++ b/glm/glm_cli/core/client.py
@@ -24,8 +24,7 @@ class GLMClient:
         """Get request headers with authentication."""
         if not self.api_token:
             raise GLMAuthError(
-                "API token not configured. "
-                "Set ACEDATACLOUD_API_TOKEN or use --token option."
+                "API token not configured. Set ACEDATACLOUD_API_TOKEN or use --token option."
             )
         return {
             "accept": "application/json",

--- a/glm/glm_cli/main.py
+++ b/glm/glm_cli/main.py
@@ -19,7 +19,7 @@ load_dotenv()
 def get_version() -> str:
     """Get the package version."""
     try:
-        return metadata.version("glm-cli")
+        return metadata.version("glm-pro-cli")
     except metadata.PackageNotFoundError:
         return "dev"
 

--- a/glm/pyproject.toml
+++ b/glm/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "glm-cli"
+name = "glm-pro-cli"
 version = "0.1.0"
 description = "CLI tool for GLM Chat Completions via AceDataCloud"
 readme = "README.md"
@@ -56,7 +56,7 @@ release = [
     "twine>=6.1.0",
 ]
 all = [
-    "glm-cli[dev,test,release]",
+    "glm-pro-cli[dev,test,release]",
 ]
 
 [project.scripts]

--- a/glm/tests/test_commands.py
+++ b/glm/tests/test_commands.py
@@ -7,7 +7,7 @@ import respx
 from click.testing import CliRunner
 from httpx import Response
 
-from glm_cli.main import cli
+from glm_cli.main import cli, get_version
 
 
 @pytest.fixture
@@ -22,6 +22,14 @@ class TestGlobalCommands:
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert "glm-cli" in result.output
+
+    def test_version_uses_distribution_name(self, monkeypatch):
+        monkeypatch.setattr(
+            "glm_cli.main.metadata.version",
+            lambda name: "1.2.3" if name == "glm-pro-cli" else None,
+        )
+
+        assert get_version() == "1.2.3"
 
     def test_help(self, runner):
         result = runner.invoke(cli, ["--help"])
@@ -55,9 +63,7 @@ class TestChatCommand:
         respx.post("https://api.acedata.cloud/glm/chat/completions").mock(
             return_value=Response(200, json=mock_chat_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "chat", "Hello"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "chat", "Hello"])
         assert result.exit_code == 0
         assert "Paris" in result.output
 
@@ -81,8 +87,13 @@ class TestChatCommand:
         result = runner.invoke(
             cli,
             [
-                "--token", "test-token", "chat", "Hello",
-                "-s", "You are a helpful assistant", "--json",
+                "--token",
+                "test-token",
+                "chat",
+                "Hello",
+                "-s",
+                "You are a helpful assistant",
+                "--json",
             ],
         )
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- keep the Clis source of truth aligned with the owned `glm-pro-cli` distribution
- preserve the existing `glm` and `glm-cli` commands
- add distribution-version regression coverage
- format three pre-existing GLM files required by the monorepo CI gate

## Verification
- `pytest` (15 passed)
- `ruff check .`
- `ruff format --check .`
- build and `twine check` passed
- source files match the GlmCli mirror PR exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)