### PR TITLE
fix(claude): remove retired model defaults

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -21,7 +21,7 @@ claude chat "What is the capital of France?"
 claude messages "Tell me a joke" --max-tokens 1024
 
 # Count tokens for a prompt
-claude count-tokens "Hello, how are you?" --model claude-3-5-haiku-20241022
+claude count-tokens "Hello, how are you?" --model claude-haiku-4-5-20251001
 
 # List available models
 claude models

--- a/claude/claude_cli/commands/chat.py
+++ b/claude/claude_cli/commands/chat.py
@@ -137,7 +137,9 @@ from claude_cli.core.output import (
     flag_value=False,
     help="Disable parallel function calling during tool use.",
 )
-@click.option("--stream", is_flag=True, default=False, help="Stream partial chat completion events.")
+@click.option(
+    "--stream", is_flag=True, default=False, help="Stream partial chat completion events."
+)
 @click.option(
     "--response-format",
     default=None,
@@ -156,7 +158,7 @@ from claude_cli.core.output import (
 @click.option(
     "--stream-options",
     default=None,
-    help='Streaming options as a JSON object (e.g. \'{"include_usage": true}\').',
+    help="Streaming options as a JSON object (e.g. '{\"include_usage\": true}').",
 )
 @click.option("--metadata", default=None, help="Metadata as a JSON object.")
 @click.option("--logit-bias", default=None, help="Logit bias map as a JSON object.")
@@ -207,7 +209,7 @@ def chat(
     \b
     Examples:
       claude chat "What is the capital of France?"
-      claude chat "Explain quantum computing" -m claude-3-5-sonnet-20241022
+      claude chat "Explain quantum computing" -m claude-sonnet-5
       claude chat "Write a poem" --temperature 0.9
       claude chat "Summarize this" -s "You are a concise summarizer"
     """

--- a/claude/claude_cli/commands/messages.py
+++ b/claude/claude_cli/commands/messages.py
@@ -80,7 +80,9 @@ from claude_cli.core.output import (
     default=None,
     help="Display mode for enabled or adaptive thinking.",
 )
-@click.option("--metadata", default=None, help='Metadata as a JSON object (e.g. \'{"user_id":"u1"}\').')
+@click.option(
+    "--metadata", default=None, help='Metadata as a JSON object (e.g. \'{"user_id":"u1"}\').'
+)
 @click.option("--stream", is_flag=True, default=False, help="Stream incremental events.")
 @click.option("--tools", default=None, help="Tool definitions as a JSON array.")
 @click.option("--tool-choice", default=None, help="Tool choice as a JSON object.")
@@ -112,7 +114,7 @@ def messages(
     \b
     Examples:
       claude messages "What is the capital of France?"
-      claude messages "Tell me a joke" -m claude-3-5-sonnet-20241022
+      claude messages "Tell me a joke" -m claude-sonnet-5
       claude messages "Explain AI" --max-tokens 2048
       claude messages "Summarize this" -s "You are a concise summarizer"
       claude messages "Think deeply" --thinking-type enabled --thinking-budget-tokens 2048
@@ -124,13 +126,17 @@ def messages(
     if thinking_type is not None:
         if thinking_type == "enabled":
             if thinking_budget_tokens is None:
-                raise click.UsageError("--thinking-budget-tokens is required when --thinking-type=enabled")
+                raise click.UsageError(
+                    "--thinking-budget-tokens is required when --thinking-type=enabled"
+                )
             thinking = {"type": thinking_type, "budget_tokens": thinking_budget_tokens}
         else:
             thinking = {"type": thinking_type}
         if thinking_display is not None:
             if thinking_type == "disabled":
-                raise click.UsageError("--thinking-display is only valid with enabled or adaptive thinking")
+                raise click.UsageError(
+                    "--thinking-display is only valid with enabled or adaptive thinking"
+                )
             thinking["display"] = thinking_display
     elif thinking_display is not None:
         raise click.UsageError("--thinking-display requires --thinking-type")
@@ -220,7 +226,7 @@ def count_tokens(
     \b
     Examples:
       claude count-tokens "What is the capital of France?"
-      claude count-tokens "Hello" -m claude-3-5-sonnet-20241022
+      claude count-tokens "Hello" -m claude-sonnet-5
       claude count-tokens "Summarize this" -s "You are a summarizer"
     """
     client = get_client(ctx.obj.get("token"))

--- a/claude/claude_cli/core/output.py
+++ b/claude/claude_cli/core/output.py
@@ -22,23 +22,15 @@ CHAT_MODELS = [
     "claude-opus-4-5-20251101",
     "claude-haiku-4-5-20251001",
     "claude-sonnet-4-5-20250929",
-    "claude-opus-4-1-20250805",
-    "claude-sonnet-4-20250514",
-    "claude-opus-4-20250514",
-    "claude-3-7-sonnet-20250219",
-    "claude-3-5-sonnet-20241022",
-    "claude-3-5-haiku-20241022",
-    "claude-3-5-sonnet-20240620",
-    "claude-3-haiku-20240307",
-    "claude-3-sonnet-20240229",
-    "claude-3-opus-20240229",
+    "claude-sonnet-5",
+    "claude-haiku-4-5-20251001",
 ]
 
 # Claude Messages API models
 MESSAGES_MODELS = CHAT_MODELS
 
-DEFAULT_CHAT_MODEL = "claude-3-5-haiku-20241022"
-DEFAULT_MESSAGES_MODEL = "claude-3-5-haiku-20241022"
+DEFAULT_CHAT_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_MESSAGES_MODEL = "claude-haiku-4-5-20251001"
 
 
 def print_json(data: Any) -> None:

--- a/claude/claude_cli/main.py
+++ b/claude/claude_cli/main.py
@@ -45,7 +45,7 @@ def cli(ctx: click.Context, token: str | None) -> None:
     \b
     Quick start:
       claude chat "What is the capital of France?"
-      claude chat "Explain AI" -m claude-3-5-sonnet-20241022
+      claude chat "Explain AI" -m claude-sonnet-5
       claude messages "Tell me a joke" --max-tokens 1024
       claude count-tokens "Hello, how are you?"
       claude models

--- a/claude/tests/conftest.py
+++ b/claude/tests/conftest.py
@@ -33,7 +33,7 @@ def mock_chat_response():
     return {
         "id": "chatcmpl-abc123",
         "object": "chat.completion",
-        "model": "claude-3-5-haiku-20241022",
+        "model": "claude-haiku-4-5-20251001",
         "choices": [
             {
                 "index": 0,
@@ -59,7 +59,7 @@ def mock_messages_response():
         "id": "msg-abc123",
         "type": "message",
         "role": "assistant",
-        "model": "claude-3-5-haiku-20241022",
+        "model": "claude-haiku-4-5-20251001",
         "content": [
             {
                 "type": "text",

--- a/claude/tests/test_client.py
+++ b/claude/tests/test_client.py
@@ -38,7 +38,7 @@ class TestClaudeClient:
             return_value=Response(200, json=mock_response)
         )
         client = ClaudeClient(api_token="test-token")
-        result = client.chat_completions(model="claude-3-5-haiku-20241022", messages=[])
+        result = client.chat_completions(model="claude-haiku-4-5-20251001", messages=[])
         assert result == mock_response
 
     @respx.mock
@@ -49,7 +49,7 @@ class TestClaudeClient:
         )
         client = ClaudeClient(api_token="test-token")
         result = client.messages(
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5-20251001",
             messages=[{"role": "user", "content": "Hi"}],
             max_tokens=1024,
         )
@@ -63,7 +63,7 @@ class TestClaudeClient:
         )
         client = ClaudeClient(api_token="test-token")
         result = client.count_tokens(
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5-20251001",
             messages=[{"role": "user", "content": "Hi"}],
         )
         assert result == mock_response
@@ -75,7 +75,7 @@ class TestClaudeClient:
         )
         client = ClaudeClient(api_token="bad-token")
         with pytest.raises(ClaudeAuthError):
-            client.chat_completions(model="claude-3-5-haiku-20241022", messages=[])
+            client.chat_completions(model="claude-haiku-4-5-20251001", messages=[])
 
     @respx.mock
     def test_403_raises_auth_error(self):
@@ -84,7 +84,7 @@ class TestClaudeClient:
         )
         client = ClaudeClient(api_token="test-token")
         with pytest.raises(ClaudeAuthError):
-            client.chat_completions(model="claude-3-5-haiku-20241022", messages=[])
+            client.chat_completions(model="claude-haiku-4-5-20251001", messages=[])
 
     @respx.mock
     def test_500_raises_api_error(self):
@@ -93,11 +93,11 @@ class TestClaudeClient:
         )
         client = ClaudeClient(api_token="test-token")
         with pytest.raises(ClaudeAPIError):
-            client.chat_completions(model="claude-3-5-haiku-20241022", messages=[])
+            client.chat_completions(model="claude-haiku-4-5-20251001", messages=[])
 
     def test_none_values_removed_from_payload(self):
         """Verify None values are stripped from request payload."""
-        payload = {"model": "claude-3-5-haiku-20241022", "temperature": None, "top_p": None}
+        payload = {"model": "claude-haiku-4-5-20251001", "temperature": None, "top_p": None}
         cleaned = {k: v for k, v in payload.items() if v is not None}
         assert "temperature" not in cleaned
         assert "top_p" not in cleaned

--- a/claude/tests/test_commands.py
+++ b/claude/tests/test_commands.py
@@ -214,9 +214,7 @@ class TestChatCommands:
         respx.post("https://api.acedata.cloud/v1/chat/completions").mock(
             return_value=Response(401, json={"error": "Unauthorized"})
         )
-        result = runner.invoke(
-            cli, ["--token", "bad-token", "chat", "Hello"]
-        )
+        result = runner.invoke(cli, ["--token", "bad-token", "chat", "Hello"])
         assert result.exit_code != 0
 
     def test_chat_no_token(self, runner, monkeypatch):
@@ -340,9 +338,7 @@ class TestMessagesCommands:
         respx.post("https://api.acedata.cloud/v1/messages").mock(
             return_value=Response(401, json={"error": "Unauthorized"})
         )
-        result = runner.invoke(
-            cli, ["--token", "bad-token", "messages", "Hello"]
-        )
+        result = runner.invoke(cli, ["--token", "bad-token", "messages", "Hello"])
         assert result.exit_code != 0
 
 
@@ -370,9 +366,7 @@ class TestCountTokensCommands:
         respx.post("https://api.acedata.cloud/v1/messages/count_tokens").mock(
             return_value=Response(200, json=mock_count_tokens_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "count-tokens", "Hello world"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "count-tokens", "Hello world"])
         assert result.exit_code == 0
         assert "15" in result.output
 
@@ -389,12 +383,12 @@ class TestCountTokensCommands:
                 "count-tokens",
                 "Hello",
                 "-m",
-                "claude-3-5-sonnet-20241022",
+                "claude-sonnet-5",
             ],
         )
         assert result.exit_code == 0
         request_body = json.loads(route.calls[0].request.content)
-        assert request_body["model"] == "claude-3-5-sonnet-20241022"
+        assert request_body["model"] == "claude-sonnet-5"
 
     @respx.mock
     def test_count_tokens_with_system(self, runner, mock_count_tokens_response):
@@ -545,9 +539,7 @@ class TestMessagesThinking:
         route = respx.post("https://api.acedata.cloud/v1/messages").mock(
             return_value=Response(200, json=mock_messages_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "messages", "Hello"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "messages", "Hello"])
         assert result.exit_code == 0
         request_body = json.loads(route.calls[0].request.content)
         assert request_body.get("thinking") is None
@@ -610,9 +602,7 @@ class TestMessagesThinking:
         route = respx.post("https://api.acedata.cloud/v1/messages/count_tokens").mock(
             return_value=Response(200, json=mock_count_tokens_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "count-tokens", "Hello"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "count-tokens", "Hello"])
         assert result.exit_code == 0
         request_body = json.loads(route.calls[0].request.content)
         assert request_body.get("thinking") is None

--- a/claude/tests/test_config.py
+++ b/claude/tests/test_config.py
@@ -1,6 +1,5 @@
 """Tests for configuration."""
 
-
 import pytest
 
 from claude_cli.core.config import Settings


### PR DESCRIPTION
Removes retired Claude model references and migrates defaults/examples to active model IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)