### PR TITLE
fix(catalog): align mapped CLI inventory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,13 @@ on:
     branches: [main]
 
 jobs:
+  inventory:
+    name: README Inventory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: python3 scripts/check_readme_inventory.py
+
   detect-changes:
     runs-on: ubuntu-latest
     outputs:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Monorepo for all AceDataCloud command-line interface tools.
 | `serp/` | [SerpCli](https://github.com/AceDataCloud/SerpCli) | Google SERP (Search) CLI |
 | `wan/` | [WanCli](https://github.com/AceDataCloud/WanCli) | Tongyi Wansiang video generation CLI |
 | `adc/` | [AceDataCloudCli](https://github.com/AceDataCloud/AceDataCloudCli) | Unified AceDataCloud CLI (all services) |
+| `aichat/` | [AiChatCli](https://github.com/AceDataCloud/AiChatCli) | AI Dialogue CLI |
+| `glm/` | [GLMCli](https://github.com/AceDataCloud/GLMCli) | GLM chat completions CLI |
+| `hailuo/` | [HailuoCli](https://github.com/AceDataCloud/HailuoCli) | Hailuo video generation CLI |
+| `kling/` | [KlingCli](https://github.com/AceDataCloud/KlingCli) | Kling video generation CLI |
+| `openai/` | [OpenAICli](https://github.com/AceDataCloud/OpenAICli) | OpenAI-compatible API CLI |
+| `producer/` | [ProducerCli](https://github.com/AceDataCloud/ProducerCli) | Producer music generation CLI |
+| `webextrator/` | [WebExtratorCli](https://github.com/AceDataCloud/WebExtratorCli) | Web extraction and rendering CLI |
 
 ## How It Works
 

--- a/aichat/aichat_cli/core/output.py
+++ b/aichat/aichat_cli/core/output.py
@@ -124,7 +124,6 @@ MODELS2 = [
     "claude-3-5-sonnet-20241022",
     "claude-3-7-sonnet-20250219",
     "claude-3-haiku-20240307",
-    "claude-3-opus-20240229",
     "claude-3-sonnet-20240229",
     "claude-haiku-4-5-20251001",
     "claude-opus-4-1-20250805",

--- a/aichat/tests/test_commands.py
+++ b/aichat/tests/test_commands.py
@@ -7,6 +7,7 @@ import respx
 from click.testing import CliRunner
 from httpx import Response
 
+from aichat_cli.core.output import MODELS2
 from aichat_cli.main import cli, get_version
 
 
@@ -20,6 +21,10 @@ def runner() -> CliRunner:
 
 class TestGlobalCommands:
     """Tests for global CLI options."""
+
+    def test_model_inventory_excludes_retired_opus_3(self):
+        assert "claude-opus-5" in MODELS2
+        assert "claude-3-opus-20240229" not in MODELS2
 
     def test_version(self, runner):
         result = runner.invoke(cli, ["--version"])

--- a/claude/claude_cli/commands/chat.py
+++ b/claude/claude_cli/commands/chat.py
@@ -137,7 +137,9 @@ from claude_cli.core.output import (
     flag_value=False,
     help="Disable parallel function calling during tool use.",
 )
-@click.option("--stream", is_flag=True, default=False, help="Stream partial chat completion events.")
+@click.option(
+    "--stream", is_flag=True, default=False, help="Stream partial chat completion events."
+)
 @click.option(
     "--response-format",
     default=None,
@@ -156,7 +158,7 @@ from claude_cli.core.output import (
 @click.option(
     "--stream-options",
     default=None,
-    help='Streaming options as a JSON object (e.g. \'{"include_usage": true}\').',
+    help="Streaming options as a JSON object (e.g. '{\"include_usage\": true}').",
 )
 @click.option("--metadata", default=None, help="Metadata as a JSON object.")
 @click.option("--logit-bias", default=None, help="Logit bias map as a JSON object.")

--- a/claude/claude_cli/commands/messages.py
+++ b/claude/claude_cli/commands/messages.py
@@ -80,7 +80,9 @@ from claude_cli.core.output import (
     default=None,
     help="Display mode for enabled or adaptive thinking.",
 )
-@click.option("--metadata", default=None, help='Metadata as a JSON object (e.g. \'{"user_id":"u1"}\').')
+@click.option(
+    "--metadata", default=None, help='Metadata as a JSON object (e.g. \'{"user_id":"u1"}\').'
+)
 @click.option("--stream", is_flag=True, default=False, help="Stream incremental events.")
 @click.option("--tools", default=None, help="Tool definitions as a JSON array.")
 @click.option("--tool-choice", default=None, help="Tool choice as a JSON object.")
@@ -124,13 +126,17 @@ def messages(
     if thinking_type is not None:
         if thinking_type == "enabled":
             if thinking_budget_tokens is None:
-                raise click.UsageError("--thinking-budget-tokens is required when --thinking-type=enabled")
+                raise click.UsageError(
+                    "--thinking-budget-tokens is required when --thinking-type=enabled"
+                )
             thinking = {"type": thinking_type, "budget_tokens": thinking_budget_tokens}
         else:
             thinking = {"type": thinking_type}
         if thinking_display is not None:
             if thinking_type == "disabled":
-                raise click.UsageError("--thinking-display is only valid with enabled or adaptive thinking")
+                raise click.UsageError(
+                    "--thinking-display is only valid with enabled or adaptive thinking"
+                )
             thinking["display"] = thinking_display
     elif thinking_display is not None:
         raise click.UsageError("--thinking-display requires --thinking-type")

--- a/claude/claude_cli/core/output.py
+++ b/claude/claude_cli/core/output.py
@@ -31,7 +31,6 @@ CHAT_MODELS = [
     "claude-3-5-sonnet-20240620",
     "claude-3-haiku-20240307",
     "claude-3-sonnet-20240229",
-    "claude-3-opus-20240229",
 ]
 
 # Claude Messages API models

--- a/claude/tests/test_commands.py
+++ b/claude/tests/test_commands.py
@@ -7,6 +7,7 @@ import respx
 from click.testing import CliRunner
 from httpx import Response
 
+from claude_cli.core.output import CHAT_MODELS
 from claude_cli.main import cli
 
 
@@ -20,6 +21,10 @@ def runner() -> CliRunner:
 
 class TestGlobalCommands:
     """Tests for global CLI options."""
+
+    def test_model_inventory_excludes_retired_opus_3(self):
+        assert "claude-opus-5" in CHAT_MODELS
+        assert "claude-3-opus-20240229" not in CHAT_MODELS
 
     def test_version(self, runner):
         result = runner.invoke(cli, ["--version"])

--- a/claude/tests/test_commands.py
+++ b/claude/tests/test_commands.py
@@ -219,9 +219,7 @@ class TestChatCommands:
         respx.post("https://api.acedata.cloud/v1/chat/completions").mock(
             return_value=Response(401, json={"error": "Unauthorized"})
         )
-        result = runner.invoke(
-            cli, ["--token", "bad-token", "chat", "Hello"]
-        )
+        result = runner.invoke(cli, ["--token", "bad-token", "chat", "Hello"])
         assert result.exit_code != 0
 
     def test_chat_no_token(self, runner, monkeypatch):
@@ -345,9 +343,7 @@ class TestMessagesCommands:
         respx.post("https://api.acedata.cloud/v1/messages").mock(
             return_value=Response(401, json={"error": "Unauthorized"})
         )
-        result = runner.invoke(
-            cli, ["--token", "bad-token", "messages", "Hello"]
-        )
+        result = runner.invoke(cli, ["--token", "bad-token", "messages", "Hello"])
         assert result.exit_code != 0
 
 
@@ -375,9 +371,7 @@ class TestCountTokensCommands:
         respx.post("https://api.acedata.cloud/v1/messages/count_tokens").mock(
             return_value=Response(200, json=mock_count_tokens_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "count-tokens", "Hello world"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "count-tokens", "Hello world"])
         assert result.exit_code == 0
         assert "15" in result.output
 
@@ -550,9 +544,7 @@ class TestMessagesThinking:
         route = respx.post("https://api.acedata.cloud/v1/messages").mock(
             return_value=Response(200, json=mock_messages_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "messages", "Hello"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "messages", "Hello"])
         assert result.exit_code == 0
         request_body = json.loads(route.calls[0].request.content)
         assert request_body.get("thinking") is None
@@ -615,9 +607,7 @@ class TestMessagesThinking:
         route = respx.post("https://api.acedata.cloud/v1/messages/count_tokens").mock(
             return_value=Response(200, json=mock_count_tokens_response)
         )
-        result = runner.invoke(
-            cli, ["--token", "test-token", "count-tokens", "Hello"]
-        )
+        result = runner.invoke(cli, ["--token", "test-token", "count-tokens", "Hello"])
         assert result.exit_code == 0
         request_body = json.loads(route.calls[0].request.content)
         assert request_body.get("thinking") is None

--- a/claude/tests/test_config.py
+++ b/claude/tests/test_config.py
@@ -1,6 +1,5 @@
 """Tests for configuration."""
 
-
 import pytest
 
 from claude_cli.core.config import Settings

--- a/scripts/check_readme_inventory.py
+++ b/scripts/check_readme_inventory.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Require README CLI inventory to match sync.yaml mappings."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    mappings = set(re.findall(r"^  ([a-z0-9_-]+):\s*$", (ROOT / "sync.yaml").read_text(), re.MULTILINE))
+    listed = set(re.findall(r"^\| `([^/`]+)/`", (ROOT / "README.md").read_text(), re.MULTILINE))
+    missing = sorted(mappings - listed)
+    extra = sorted(listed - mappings)
+    if missing or extra:
+        if missing:
+            print(f"README missing mapped CLIs: {', '.join(missing)}", file=sys.stderr)
+        if extra:
+            print(f"README lists unmapped CLIs: {', '.join(extra)}", file=sys.stderr)
+        return 1
+    print(f"README inventory matches {len(mappings)} mapped CLIs")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Contract node
CLI publication inventory.

## Changes
- add the 7 mapped CLIs omitted from README
- add an always-on README ↔ `sync.yaml` CI gate

## Evidence
`README inventory matches 18 mapped CLIs`; Python compile, workflow YAML parse, and diff check passed.

## Rollout / rollback
Documentation/CI only; revert safely.

## Dependencies
Independent.

## Out of scope
Unmapped package directories are not automatically advertised. Adversarial review was not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: retired Claude Opus 3

- Removes `claude-3-opus-20240229` from the Claude and AIChat CLI model inventories after it disappeared from the authenticated live `/v1/models` response.
- Keeps `claude-opus-5` as the current stable Opus choice.
- Adds package-level regression tests that pin both facts.

This retirement closes together with https://github.com/AceDataCloud/PlatformBackend/pull/1507, https://github.com/AceDataCloud/MCPs/pull/662, and https://github.com/AceDataCloud/Dify/pull/405.

Additional validation: `claude/tests/test_commands.py` (41 passed), `aichat/tests/test_commands.py` (42 passed).