### PR TITLE
feat(seedance): align CLI auto duration controls

### DIFF
--- a/seedance/README.md
+++ b/seedance/README.md
@@ -14,7 +14,7 @@ Generate AI videos directly from your terminal — no MCP client required.
 
 - **Video Generation** — Generate videos from text prompts with multiple models
 - **Image-to-Video** — Create videos from reference images
-- **Multiple Models** — Seedance 2.0 series (doubao-seedance-2-5-260628, doubao-seedance-2-0-fast-260128, doubao-seedance-2-0-mini-260615) plus doubao-seedance-1-5-pro-251215, doubao-seedance-1-0-pro-250528, doubao-seedance-1-0-pro-fast-251015, doubao-seedance-1-0-lite-t2v-250428, doubao-seedance-1-0-lite-i2v-250428
+- **Multiple Models** — Seedance 2.5 plus the Seedance 2.0 series ( doubao-seedance-2-0-fast-260128, doubao-seedance-2-0-mini-260615) plus doubao-seedance-1-5-pro-251215, doubao-seedance-1-0-pro-250528, doubao-seedance-1-0-pro-fast-251015, doubao-seedance-1-0-lite-t2v-250428, doubao-seedance-1-0-lite-i2v-250428
 - **Task Management** — Query tasks, batch query, wait with polling
 - **Rich Output** — Beautiful terminal tables and panels via Rich
 - **JSON Mode** — Machine-readable output with `--json` for piping
@@ -104,7 +104,7 @@ Most commands support:
 --model TEXT                 Seedance model version (default: doubao-seedance-2-0-260128)
 --aspect-ratio TEXT          Aspect ratio (16:9, 9:16, 1:1, 4:3, 3:4, 21:9, adaptive)
 --resolution TEXT            Output resolution (480p, 720p, 1080p, 4k)
---duration INT               Duration in seconds (-1 for auto, up to 30). Mutually exclusive with --frames.
+--duration INT               Duration in seconds (-1 for auto, up to 15 for 2.0 or 30 for 2.5). Mutually exclusive with --frames.
 --frames INT                 Frame count (29–289, must satisfy 25+4n). Mutually exclusive with --duration.
 --seed INT                   Random seed for reproducible generation (-1 for random).
 --camerafixed BOOL           Fix the camera position (true/false).

--- a/seedance/seedance_cli/commands/video.py
+++ b/seedance/seedance_cli/commands/video.py
@@ -277,9 +277,13 @@ def _build_content(
         if url is not None:
             content.append({"type": "image_url", "role": role, "image_url": {"url": url}})
     for audio_url in audio_urls:
-        content.append({"type": "audio_url", "role": "reference_audio", "audio_url": {"url": audio_url}})
+        content.append(
+            {"type": "audio_url", "role": "reference_audio", "audio_url": {"url": audio_url}}
+        )
     for video_url in video_urls:
-        content.append({"type": "video_url", "role": "reference_video", "video_url": {"url": video_url}})
+        content.append(
+            {"type": "video_url", "role": "reference_video", "video_url": {"url": video_url}}
+        )
     return content
 
 

--- a/seedance/seedance_cli/commands/video.py
+++ b/seedance/seedance_cli/commands/video.py
@@ -138,13 +138,15 @@ def _shared_video_options(f):  # type: ignore[no-untyped-def]
         ),
         click.option(
             "--audio-url",
-            default=None,
-            help="Reference audio URL.",
+            "audio_urls",
+            multiple=True,
+            help="Reference audio URL; repeat for multiple references.",
         ),
         click.option(
             "--video-url",
-            default=None,
-            help="Reference video URL.",
+            "video_urls",
+            multiple=True,
+            help="Reference video URL; repeat for multiple references.",
         ),
         click.option(
             "--async",
@@ -210,8 +212,8 @@ def _build_common_payload(
     if priority is not None:
         payload["priority"] = priority
     if safety_identifier is not None:
-        if len(safety_identifier) > 64:
-            raise click.UsageError("--safety-identifier must be at most 64 characters.")
+        if not safety_identifier or len(safety_identifier) > 64:
+            raise click.UsageError("--safety-identifier must contain 1-64 characters.")
         payload["safety_identifier"] = safety_identifier
     if execution_expires_after is not None:
         payload["execution_expires_after"] = execution_expires_after
@@ -261,8 +263,8 @@ def _build_content(
     first_frame_url: str | None,
     last_frame_url: str | None,
     reference_image_urls: tuple[str, ...],
-    audio_url: str | None,
-    video_url: str | None,
+    audio_urls: tuple[str, ...],
+    video_urls: tuple[str, ...],
 ) -> list[dict[str, object]]:
     """Build request content items from the supported reference media inputs."""
     content: list[dict[str, object]] = [{"type": "text", "text": prompt}]
@@ -274,22 +276,10 @@ def _build_content(
     for url, role in image_sources:
         if url is not None:
             content.append({"type": "image_url", "role": role, "image_url": {"url": url}})
-    if audio_url is not None:
-        content.append(
-            {
-                "type": "audio_url",
-                "role": "reference_audio",
-                "audio_url": {"url": audio_url},
-            }
-        )
-    if video_url is not None:
-        content.append(
-            {
-                "type": "video_url",
-                "role": "reference_video",
-                "video_url": {"url": video_url},
-            }
-        )
+    for audio_url in audio_urls:
+        content.append({"type": "audio_url", "role": "reference_audio", "audio_url": {"url": audio_url}})
+    for video_url in video_urls:
+        content.append({"type": "video_url", "role": "reference_video", "video_url": {"url": video_url}})
     return content
 
 
@@ -320,8 +310,8 @@ def generate(
     first_frame_url: str | None,
     last_frame_url: str | None,
     reference_image_urls: tuple[str, ...],
-    audio_url: str | None,
-    video_url: str | None,
+    audio_urls: tuple[str, ...],
+    video_urls: tuple[str, ...],
     async_mode: bool,
     output_json: bool,
 ) -> None:
@@ -367,8 +357,8 @@ def generate(
             first_frame_url=first_frame_url,
             last_frame_url=last_frame_url,
             reference_image_urls=reference_image_urls,
-            audio_url=audio_url,
-            video_url=video_url,
+            audio_urls=audio_urls,
+            video_urls=video_urls,
         )
 
         result = client.generate_video(**payload)  # type: ignore[arg-type]
@@ -417,8 +407,8 @@ def image_to_video(
     first_frame_url: str | None,
     last_frame_url: str | None,
     reference_image_urls: tuple[str, ...],
-    audio_url: str | None,
-    video_url: str | None,
+    audio_urls: tuple[str, ...],
+    video_urls: tuple[str, ...],
     async_mode: bool,
     output_json: bool,
 ) -> None:
@@ -464,8 +454,8 @@ def image_to_video(
             first_frame_url=first_frame_url,
             last_frame_url=last_frame_url,
             reference_image_urls=image_urls + reference_image_urls,
-            audio_url=audio_url,
-            video_url=video_url,
+            audio_urls=audio_urls,
+            video_urls=video_urls,
         )
 
         result = client.generate_video(**payload)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- support repeatable audio/video references and model-specific automatic duration
- validate web-search tools and expose priority/safety controls
- remove stale service-tier documentation

## Dependency
Publish after the core Seedance runtime and billing PRs.

## Validation
- pytest: 59 passed, 1 skipped
- Ruff and mypy passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)