### PR TITLE
fix: sync hyphenated subdirectories

### DIFF
--- a/.github/workflows/sync-to-repos.yml
+++ b/.github/workflows/sync-to-repos.yml
@@ -40,7 +40,7 @@ jobs:
           CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD)
 
           # Read sync.yaml to get mapping keys
-          DIRS=$(grep -E '^\s+\w+:$' sync.yaml | sed 's/://;s/^\s*//' | grep -v '^repo$\|^exclude$\|^mappings$')
+          DIRS=$(grep -E '^\s+[A-Za-z0-9_-]+:$' sync.yaml | sed 's/://;s/^\s*//' | grep -v '^repo$\|^exclude$\|^mappings$')
 
           MATRIX="[]"
           HAS_CHANGES="false"
@@ -111,7 +111,7 @@ jobs:
               fi
             fi
             # Reset if we hit a new top-level dir mapping
-            if echo "$line" | grep -qE '^\s+\w+:$' && [ "$IN_DIR" = true ]; then
+            if echo "$line" | grep -qE '^\s+[A-Za-z0-9_-]+:$' && [ "$IN_DIR" = true ]; then
               break
             fi
           done < "$GITHUB_WORKSPACE/sync.yaml"


### PR DESCRIPTION
The aggregate mirror workflow only matched `\w+` keys, silently skipping mappings such as `qwen-image`. This widens both mapping-key regexes to `[A-Za-z0-9_-]+`. The Qwen mirrors were initialized manually for this release; this fix keeps future aggregate pushes synchronized.

Validation: workflow diff review and `git diff --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)